### PR TITLE
Add Bond and Coop RPC

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -6,7 +6,7 @@ import (
 
 var DonateBalance = "10"                                                             // we send this amount free to invesotrs who signup on our platform to enable them to have trustlines. Maybe we should have a payment provider and take money from them?
 var StablecoinTrustLimit = "100000"                                                  // the maximum limit that the investor trusts the stablecoin issuer for
-var INVAssetPrefix = "INVTokens_"                                                    // the prefix that will be hashed to give an invesotr AssetID
+var INVAssetPrefix = "BondTokens_"                                                    // the prefix that will be hashed to give an invesotr AssetID
 var DEBAssetPrefix = "DEBTokens_"                                                    // the prefix that will be hashed to give a recipient AssetID
 var PBAssetPrefix = "PBTokens_"                                                      // the prefix that will be hashed to give a payback AssetID
 var HomeDir = os.Getenv("HOME") + "/.openfinancing"                                      // home directory where we store the platform seed

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -6,13 +6,15 @@ import (
 
 var DonateBalance = "10"                                                             // we send this amount free to invesotrs who signup on our platform to enable them to have trustlines. Maybe we should have a payment provider and take money from them?
 var StablecoinTrustLimit = "100000"                                                  // the maximum limit that the investor trusts the stablecoin issuer for
-var INVAssetPrefix = "BondTokens_"                                                    // the prefix that will be hashed to give an invesotr AssetID
+var INVAssetPrefix = "BondTokens_"                                                   // the prefix that will be hashed to give an investor AssetID
+var BondAssetPrefix = "BondTokens_"                                                  // the prefix that will be hashed to give a bond asset
+var CoopAssetPrefix = "CoopAsset_"                                                   // the prefix that will be hashed to give the cooperative asset
 var DEBAssetPrefix = "DEBTokens_"                                                    // the prefix that will be hashed to give a recipient AssetID
 var PBAssetPrefix = "PBTokens_"                                                      // the prefix that will be hashed to give a payback AssetID
-var HomeDir = os.Getenv("HOME") + "/.openfinancing"                                      // home directory where we store the platform seed
+var HomeDir = os.Getenv("HOME") + "/.openfinancing"                                  // home directory where we store the platform seed
 var PlatformSeedFile = HomeDir + "/platformseed.hex"                                 // the path where the platform's seed is stored
 var StableCoinSeedFile = HomeDir + "/stablecoinseed.hex"                             // the path where the stablecoin's seed is stored
 var DbDir = HomeDir + "/database"                                                    // the directory where the main assets of our platform are stored
 var IpfsFileLength = 10                                                              // the length of the hash that we want our ipfs hashes to have
 const StableCoinAddress = "GBY3DHWSN5CHJ5FDHD7PI5Q23NNMJAK7MGRSERKMOV6QBR7IMAI3IWK5" // the address of the stabellcoin must be a constant for the payment listener to work properly
-var TellerHomeDir = os.Getenv("HOME") + "/.openfinancing/teller"                         // the hom directory of the teller executable
+var TellerHomeDir = os.Getenv("HOME") + "/.openfinancing/teller"                     // the hom directory of the teller executable

--- a/database/assets.go
+++ b/database/assets.go
@@ -1,0 +1,61 @@
+package database
+
+import (
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	xlm "github.com/OpenFinancing/openfinancing/xlm"
+	"github.com/stellar/go/build"
+)
+
+// CreateAsset creates a new asset belonging to the public key referenced above
+func CreateAsset(assetName string, PublicKey string) build.Asset {
+	// need to set a couple flags here
+	return build.CreditAsset(assetName, PublicKey)
+}
+
+func AssetID(inputString string) string {
+	// so the assetID right now is a hash of the asset name, concatenated investor public keys and nonces
+	x := utils.SHA3hash(inputString)
+	return "YOL" + x[64:73] // max length of an asset in stellar is 12
+	// log.Fatal(fmt.Errorf("All good"))
+	// return nil
+}
+
+// TrustAsset trusts a specific asset issued by a particular public key and signs
+// a transaction with a preset limit on how much it is willing to trsut that issuer's
+// asset for
+func TrustAsset(asset build.Asset, limit string, PublicKey string, Seed string) (string, error) {
+	// TRUST is FROM recipient TO issuer
+	trustTx, err := build.Transaction(
+		build.SourceAccount{PublicKey},
+		build.AutoSequence{SequenceProvider: xlm.TestNetClient},
+		build.TestNetwork,
+		build.Trust(asset.Code, asset.Issuer, build.Limit(limit)),
+	)
+
+	_, txHash, err := xlm.SendTx(Seed, trustTx)
+	return txHash, err
+}
+
+
+// SendAsset transfers _amount_ number of assets from the caller to the destination
+// and returns an error if the destination doesn't have a trustline with the issuer
+// This method is called by the issuer of the asset
+func SendAssetFromIssuer(assetName string, destination string, amount string, Seed string, PublicKey string) (int32, string, error) {
+	// this transaction is FROM issuer TO recipient
+	paymentTx, err := build.Transaction(
+		build.SourceAccount{PublicKey},
+		build.TestNetwork,
+		build.AutoSequence{SequenceProvider: xlm.TestNetClient},
+		build.MemoText{"Sending Asset: " + assetName},
+		build.Payment(
+			build.Destination{AddressOrSeed: destination},
+			build.CreditAmount{assetName, PublicKey, amount},
+			// CreditAmount identifies the asset by asset Code and issuer pubkey
+		),
+	)
+
+	if err != nil {
+		return -1, "", err
+	}
+	return xlm.SendTx(Seed, paymentTx)
+}

--- a/database/bonds.go
+++ b/database/bonds.go
@@ -137,7 +137,7 @@ func RetrieveBond(key int) (ConstructionBond, error) {
 
 // for the demo, the publickey and seed must be hardcoded and  given as a binary I guess
 // or worse, hardcode the seed and pubkey in the functions themselves
-func (a *ConstructionBond) InvestInProject(issuerPublicKey string, issuerSeed string, investor *Investor,
+func (a *ConstructionBond) Invest(issuerPublicKey string, issuerSeed string, investor *Investor,
 	recipient *Recipient, investmentAmountS string, investorSeed string, recipientSeed string) error {
 	// we want to invest in this specific bond
 	var err error
@@ -151,7 +151,7 @@ func (a *ConstructionBond) InvestInProject(issuerPublicKey string, issuerSeed st
 
 	if a.Params.INVAssetCode == "" {
 		// this person is the first investor, set the investor token name
-		INVAssetCode := AssetID(consts.INVAssetPrefix + assetName)
+		INVAssetCode := AssetID(consts.BondAssetPrefix + assetName)
 		a.Params.INVAssetCode = INVAssetCode           // set the investeor code
 		_ = CreateAsset(INVAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
 	}

--- a/database/bonds.go
+++ b/database/bonds.go
@@ -1,0 +1,192 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	consts "github.com/OpenFinancing/openfinancing/consts"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	// assets "github.com/OpenFinancing/openfinancing/assets"
+	"github.com/boltdb/bolt"
+	"github.com/stellar/go/build"
+)
+
+type BondParams struct {
+	Index          int
+	MaturationDate string
+	MemberRights   string
+	SecurityType   string
+	InterestRate   float64
+	Rating         string
+	BondIssuer     string
+	Underwriter    string
+	DateInitiated  string // date the project was created
+	INVAssetCode   string
+}
+
+type ConstructionBond struct {
+	Params BondParams
+	// common set of params that we need for openfinancing
+	AmountRaised   float64
+	CostOfUnit     float64
+	InstrumentType string
+	NoOfUnits      int
+	Tax            string
+	Investors      []Investor
+	RecipientIndex int
+}
+
+func newParams(mdate string, mrights string, stype string, intrate float64, rating string,
+	bIssuer string, uWriter string) BondParams {
+	var rParams BondParams
+	rParams.MaturationDate = mdate
+	rParams.MemberRights = mrights
+	rParams.SecurityType = stype
+	rParams.InterestRate = intrate
+	rParams.Rating = rating
+	rParams.BondIssuer = bIssuer
+	rParams.Underwriter = uWriter
+	rParams.DateInitiated = utils.Timestamp()
+	return rParams
+}
+
+func NewBond(mdate string, mrights string, stype string, intrate float64, rating string,
+	bIssuer string, uWriter string, unitCost float64, itype string, nUnits int, tax string, recIndex int) (ConstructionBond, error) {
+	var cBond ConstructionBond
+	cBond.Params = newParams(mdate, mrights, stype, intrate, rating, bIssuer, uWriter)
+	x, err := RetrieveAllBonds()
+	if err != nil {
+		return cBond, err
+	}
+
+	cBond.Params.Index = len(x) + 1
+	cBond.CostOfUnit = unitCost
+	cBond.InstrumentType = itype
+	cBond.NoOfUnits = nUnits
+	cBond.Tax = tax
+	cBond.RecipientIndex = recIndex
+	err = cBond.Save()
+	return cBond, err
+}
+
+func (a *ConstructionBond) Save() error {
+	db, err := OpenDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BondBucket)
+		encoded, err := json.Marshal(a)
+		if err != nil {
+			log.Println("Failed to encode this data into json")
+			return err
+		}
+		return b.Put([]byte(utils.ItoB(a.Params.Index)), encoded)
+	})
+	return err
+}
+
+// RetrieveAllBonds gets a list of all User in the database
+func RetrieveAllBonds() ([]ConstructionBond, error) {
+	var arr []ConstructionBond
+	db, err := OpenDB()
+	if err != nil {
+		return arr, err
+	}
+	defer db.Close()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BondBucket)
+		for i := 1; ; i++ {
+			var rBond ConstructionBond
+			x := b.Get(utils.ItoB(i))
+			if x == nil {
+				return nil
+			}
+			err := json.Unmarshal(x, &rBond)
+			if err != nil {
+				return err
+			}
+			arr = append(arr, rBond)
+		}
+		return nil
+	})
+	return arr, err
+}
+
+func RetrieveBond(key int) (ConstructionBond, error) {
+	var bond ConstructionBond
+	db, err := OpenDB()
+	if err != nil {
+		return bond, err
+	}
+	defer db.Close()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(BondBucket)
+		x := b.Get(utils.ItoB(key))
+		if x == nil {
+			return nil
+		}
+		return json.Unmarshal(x, &bond)
+	})
+	return bond, err
+}
+
+// for the demo, the publickey and seed must be hardcoded and  given as a binary I guess
+// or worse, hardcode the seed and pubkey in the functions themselves
+func (a *ConstructionBond) InvestInProject(issuerPublicKey string, issuerSeed string, investor *Investor,
+	recipient *Recipient, investmentAmountS string, investorSeed string, recipientSeed string) error {
+	// we want to invest in this specific bond
+	var err error
+	investmentAmount := utils.StoI(investmentAmountS)
+	// check if investment amount is greater than the cost of a unit
+	if float64(investmentAmount) > a.CostOfUnit {
+		fmt.Println("You are trying to invest more than a unit's cost, do you want to invest in two units?")
+		return fmt.Errorf("You are trying to invest more than a unit's cost, do you want to invest in two units?")
+	}
+	assetName := AssetID(a.Params.MaturationDate + a.Params.SecurityType + a.Params.Rating + a.Params.BondIssuer) // get a unique assetID
+
+	if a.Params.INVAssetCode == "" {
+		// this person is the first investor, set the investor token name
+		INVAssetCode := AssetID(consts.INVAssetPrefix + assetName)
+		a.Params.INVAssetCode = INVAssetCode           // set the investeor code
+		_ = CreateAsset(INVAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
+	}
+	/*
+		dont check stableUSD balance for now
+		if !investor.CanInvest(investor.U.PublicKey, investmentAmountS) {
+			log.Println("Investor has less balance than what is required to ivnest in this asset")
+			return a, err
+		}
+	*/
+	var INVAsset build.Asset
+	INVAsset.Code = a.Params.INVAssetCode
+	INVAsset.Issuer = issuerPublicKey
+	// make in v estor trust the asset that we provide
+	txHash, err := TrustAsset(INVAsset, utils.FtoS(a.CostOfUnit*float64(a.NoOfUnits)), investor.U.PublicKey, investorSeed)
+	// trust upto the total value of the asset
+	if err != nil {
+		return err
+	}
+	log.Println("Investor trusted asset: ", INVAsset.Code, " tx hash: ", txHash)
+	log.Println("Sending INVAsset: ", INVAsset.Code, "for: ", investmentAmount)
+	_, txHash, err = SendAssetFromIssuer(INVAsset.Code, investor.U.PublicKey, investmentAmountS, issuerSeed, issuerPublicKey)
+	if err != nil {
+		return err
+	}
+	log.Printf("Sent INVAsset %s to investor %s with txhash %s", INVAsset.Code, investor.U.PublicKey, txHash)
+	// investor asset sent, update a.Params's BalLeft
+	a.AmountRaised += float64(investmentAmount)
+	investor.AmountInvested += float64(investmentAmount)
+	investor.InvestedBonds = append(investor.InvestedBonds, a.Params.INVAssetCode)
+	err = investor.Save() // save investor creds now that we're done
+	if err != nil {
+		return err
+	}
+	a.Investors = append(a.Investors, *investor)
+	err = a.Save()
+	return err
+}

--- a/database/coop.go
+++ b/database/coop.go
@@ -1,9 +1,196 @@
 package database
 
-type LivingUintCoop struct {
-	Params         DBParams
+import (
+	"fmt"
+	consts "github.com/OpenFinancing/openfinancing/consts"
+
+	"github.com/stellar/go/build"
+
+	"encoding/json"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	"github.com/boltdb/bolt"
+	"log"
+)
+
+/*
+type BondParams struct {
+	Index          int
+	MaturationDate string
+	MemberRights   string
+	SecurityType   string
+	InterestRate   float64
+	Rating         string
+	BondIssuer     string
+	Underwriter    string
+	DateInitiated  string // date the project was created
+	INVAssetCode   string
+}
+*/
+type Coop struct {
+	Params         BondParams
 	UnitsSold      int
 	TotalAmount    float64
 	TypeOfUnit     string
-	MonthlyPayment int
+	MonthlyPayment float64
+	Residents      []Investor
+}
+
+func NewCoop(mdate string, mrights string, stype string, intrate float64, rating string,
+	bIssuer string, uWriter string, totalAmount float64, typeOfUnit string, monthlyPayment float64) (Coop, error) {
+	var cCoop Coop
+	cCoop.Params = newParams(mdate, mrights, stype, intrate, rating, bIssuer, uWriter)
+	x, err := RetrieveAllCoops()
+	if err != nil {
+		return cCoop, err
+	}
+
+	cCoop.Params.Index = len(x) + 1
+	cCoop.UnitsSold = 0
+	cCoop.TotalAmount = totalAmount
+	cCoop.TypeOfUnit = typeOfUnit
+	cCoop.MonthlyPayment = monthlyPayment
+	err = cCoop.Save()
+	return cCoop, err
+}
+
+func (a *Coop) Save() error {
+	db, err := OpenDB()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(CoopBucket)
+		encoded, err := json.Marshal(a)
+		if err != nil {
+			log.Println("Failed to encode this data into json")
+			return err
+		}
+		return b.Put([]byte(utils.ItoB(a.Params.Index)), encoded)
+	})
+	return err
+}
+
+// RetrieveAllBonds gets a list of all User in the database
+func RetrieveAllCoops() ([]Coop, error) {
+	var arr []Coop
+	db, err := OpenDB()
+	if err != nil {
+		return arr, err
+	}
+	defer db.Close()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(CoopBucket)
+		for i := 1; ; i++ {
+			var rCoop Coop
+			x := b.Get(utils.ItoB(i))
+			if x == nil {
+				return nil
+			}
+			err := json.Unmarshal(x, &rCoop)
+			if err != nil {
+				return err
+			}
+			arr = append(arr, rCoop)
+		}
+		return nil
+	})
+	return arr, err
+}
+
+func RetrieveCoop(key int) (Coop, error) {
+	var bond Coop
+	db, err := OpenDB()
+	if err != nil {
+		return bond, err
+	}
+	defer db.Close()
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(CoopBucket)
+		x := b.Get(utils.ItoB(key))
+		if x == nil {
+			return nil
+		}
+		return json.Unmarshal(x, &bond)
+	})
+	return bond, err
+}
+
+/*
+type BondParams struct {
+	Index          int
+	MaturationDate string
+	MemberRights   string
+	SecurityType   string
+	InterestRate   float64
+	Rating         string
+	BondIssuer     string
+	Underwriter    string
+	DateInitiated  string // date the project was created
+	INVAssetCode   string
+}
+type Coop struct {
+	Params         BondParams
+	UnitsSold      int
+	TotalAmount    float64
+	TypeOfUnit     string
+	MonthlyPayment float64
+}
+*/
+// for the demo, the publickey and seed must be hardcoded and  given as a binary I guess
+// or worse, hardcode the seed and pubkey in the functions themselves
+func (a *Coop) Invest(issuerPublicKey string, issuerSeed string, investor *Investor,
+	investmentAmountS string, investorSeed string) error {
+	// we want to invest in this specific bond
+	var err error
+	investmentAmount := utils.StoI(investmentAmountS)
+	// check if investment amount is greater than the cost of a unit
+	if float64(investmentAmount) > a.MonthlyPayment || float64(investmentAmount) < a.MonthlyPayment {
+		fmt.Println("You are trying to invest more or less than a month's payment")
+		return fmt.Errorf("You are trying to invest more or less than a month's payment")
+	}
+	assetName := AssetID(a.Params.MaturationDate + a.Params.SecurityType + a.Params.Rating + a.Params.BondIssuer) // get a unique assetID
+
+	if a.Params.INVAssetCode == "" {
+		// this person is the first investor, set the investor token name
+		INVAssetCode := AssetID(consts.CoopAssetPrefix + assetName)
+		a.Params.INVAssetCode = INVAssetCode           // set the investeor code
+		_ = CreateAsset(INVAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
+	}
+	/*
+		dont check stableUSD balance for now
+		if !investor.CanInvest(investor.U.PublicKey, investmentAmountS) {
+			log.Println("Investor has less balance than what is required to ivnest in this asset")
+			return a, err
+		}
+	*/
+	var INVAsset build.Asset
+	INVAsset.Code = a.Params.INVAssetCode
+	INVAsset.Issuer = issuerPublicKey
+	// make in v estor trust the asset that we provide
+	txHash, err := TrustAsset(INVAsset, utils.FtoS(a.TotalAmount), investor.U.PublicKey, investorSeed)
+	// trust upto the total value of the asset
+	if err != nil {
+		return err
+	}
+	log.Println("Investor trusted asset: ", INVAsset.Code, " tx hash: ", txHash)
+	log.Println("Sending INVAsset: ", INVAsset.Code, "for: ", investmentAmount)
+	_, txHash, err = SendAssetFromIssuer(INVAsset.Code, investor.U.PublicKey, investmentAmountS, issuerSeed, issuerPublicKey)
+	if err != nil {
+		return err
+	}
+	log.Printf("Sent INVAsset %s to investor %s with txhash %s", INVAsset.Code, investor.U.PublicKey, txHash)
+	// investor asset sent, update a.Params's BalLeft
+	a.UnitsSold += 1
+	investor.AmountInvested += float64(investmentAmount)
+	investor.InvestedCoops = append(investor.InvestedCoops, a.Params.INVAssetCode)
+	err = investor.Save() // save investor creds now that we're done
+	if err != nil {
+		return err
+	}
+	a.Residents = append(a.Residents, *investor)
+	err = a.Save()
+	return err
 }

--- a/database/coop.go
+++ b/database/coop.go
@@ -1,0 +1,9 @@
+package database
+
+type LivingUintCoop struct {
+	Params         DBParams
+	UnitsSold      int
+	TotalAmount    float64
+	TypeOfUnit     string
+	MonthlyPayment int
+}

--- a/database/database.go
+++ b/database/database.go
@@ -15,6 +15,8 @@ var InvestorBucket = []byte("Investors")
 var RecipientBucket = []byte("Recipients")
 var ContractorBucket = []byte("Contractors")
 var UserBucket = []byte("Users")
+var BondBucket = []byte("Bonds")
+var CoopBucket = []byte("Coop")
 
 func CreateHomeDir() {
 	if _, err := os.Stat(consts.HomeDir); os.IsNotExist(err) {
@@ -53,6 +55,14 @@ func OpenDB() (*bolt.DB, error) {
 			return err
 		}
 		_, err = tx.CreateBucketIfNotExists(UserBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(BondBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(CoopBucket) // the projects bucket contains all our projects
 		if err != nil {
 			return err
 		}

--- a/database/database.go
+++ b/database/database.go
@@ -61,6 +61,41 @@ func OpenDB() (*bolt.DB, error) {
 	return db, err
 }
 
+// TODO: need locks over this to ensure no one's using the db while we are
+func OpenDBTest() (*bolt.DB, error) {
+	// we need to check and create this directory if it doesn't exist
+	db, err := bolt.Open("yol.db", 0600, nil) // store this in its ownd database
+	if err != nil {
+		log.Println("Couldn't open database, exiting!")
+		return db, err
+	}
+	err = db.Update(func(tx *bolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(ProjectsBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(InvestorBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(RecipientBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(ContractorBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		_, err = tx.CreateBucketIfNotExists(UserBucket) // the projects bucket contains all our projects
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return db, err
+}
+
+
 // DeleteProject deltes a given value corresponding to the ky from the database
 // DeleteProject should be used only in cases where something is wrong from our side
 // while creating an project. For other cases, we should set Live to False and edit

--- a/database/database.go
+++ b/database/database.go
@@ -61,41 +61,6 @@ func OpenDB() (*bolt.DB, error) {
 	return db, err
 }
 
-// TODO: need locks over this to ensure no one's using the db while we are
-func OpenDBTest() (*bolt.DB, error) {
-	// we need to check and create this directory if it doesn't exist
-	db, err := bolt.Open("yol.db", 0600, nil) // store this in its ownd database
-	if err != nil {
-		log.Println("Couldn't open database, exiting!")
-		return db, err
-	}
-	err = db.Update(func(tx *bolt.Tx) error {
-		_, err := tx.CreateBucketIfNotExists(ProjectsBucket) // the projects bucket contains all our projects
-		if err != nil {
-			return err
-		}
-		_, err = tx.CreateBucketIfNotExists(InvestorBucket) // the projects bucket contains all our projects
-		if err != nil {
-			return err
-		}
-		_, err = tx.CreateBucketIfNotExists(RecipientBucket) // the projects bucket contains all our projects
-		if err != nil {
-			return err
-		}
-		_, err = tx.CreateBucketIfNotExists(ContractorBucket) // the projects bucket contains all our projects
-		if err != nil {
-			return err
-		}
-		_, err = tx.CreateBucketIfNotExists(UserBucket) // the projects bucket contains all our projects
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	return db, err
-}
-
-
 // DeleteProject deltes a given value corresponding to the ky from the database
 // DeleteProject should be used only in cases where something is wrong from our side
 // while creating an project. For other cases, we should set Live to False and edit

--- a/database/investors.go
+++ b/database/investors.go
@@ -28,6 +28,7 @@ type Investor struct {
 	// total amount, would be nice to track to contact them,
 	// give them some kind of medals or something
 	InvestedAssets []DBParams
+	InvestedBonds []string
 	// array of asset codes this user has invested in
 	// also I think we need a username + password for logging on to the platform itself
 	// linking it here for now

--- a/database/investors.go
+++ b/database/investors.go
@@ -29,6 +29,7 @@ type Investor struct {
 	// give them some kind of medals or something
 	InvestedAssets []DBParams
 	InvestedBonds []string
+	InvestedCoops []string
 	// array of asset codes this user has invested in
 	// also I think we need a username + password for logging on to the platform itself
 	// linking it here for now

--- a/database/search.go
+++ b/database/search.go
@@ -1,0 +1,17 @@
+package database
+
+import (
+	"strings"
+)
+
+// need to build a search endpoitn so that we can serach for x and then return results
+// in this example, we can search for bonds / coops and then return bonds/coops accoridngly
+// this should be in the rpc package I guess, so don't do much until we take it there
+func TestSearch(param string) {
+	// param is the search string that you enter
+	if strings.Contains(param, "bond") {
+		// tkae bond actions
+	} else if strings.Contains(param, "coop") {
+		// do coop stuff
+	}
+}

--- a/database/users.go
+++ b/database/users.go
@@ -7,6 +7,7 @@ import (
 
 	aes "github.com/OpenFinancing/openfinancing/aes"
 	utils "github.com/OpenFinancing/openfinancing/utils"
+	wallet "github.com/OpenFinancing/openfinancing/wallet"
 	xlm "github.com/OpenFinancing/openfinancing/xlm"
 	"github.com/boltdb/bolt"
 )
@@ -185,4 +186,8 @@ func (a *User) GenKeys(seedpwd string) error {
 	a.EncryptedSeed, err = aes.Encrypt([]byte(seed), seedpwd)
 	err = a.Save()
 	return err
+}
+
+func (a *User) GetSeed(seedpwd string) (string, error) {
+	return wallet.DecryptSeed(a.EncryptedSeed, seedpwd)
 }

--- a/rpc/bonds.go
+++ b/rpc/bonds.go
@@ -1,0 +1,139 @@
+package rpc
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	database "github.com/OpenFinancing/openfinancing/database"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	xlm "github.com/OpenFinancing/openfinancing/xlm"
+)
+
+func setupBondRPCs() {
+	InvestInBond()
+	getBondDetails()
+}
+
+func CreateBond() {
+	// newParams(mdate string, mrights string, stype string, intrate float64, rating string, bIssuer string, uWriter string
+	// unitCost float64, itype string, nUnits int, tax string
+	var bond1 database.ConstructionBond
+	var err error
+	bond1, err = database.NewBond("Dec 21 2049", "Maturation Rights Link", "Security Type", 5.4, "AAA", "Bond Issuer", "underwriter.com",
+		100000, "Instrument Type", 100, "No Fed tax for 10 years", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Println("BOND INDEX: ", bond1.Params.Index)
+	_, err = database.RetrieveBond(bond1.Params.Index)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// curl request attached for convenience
+// curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Origin: localhost" -H "Cache-Control: no-cache" -d 'InvestmentAmount=1000&BondIndex=1&InvIndex=2&InvSeedPwd=x&RecSeedPwd=x' "http://localhost:8080/bond/invest"
+func InvestInBond() {
+	http.HandleFunc("/bond/invest", func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		var iBond database.ConstructionBond
+		// need to receive a whole lot of parameters here
+		// need the bond index passed so that we can retrieve the bond easily
+		if r.FormValue("InvestmentAmount") == "" || r.FormValue("BondIndex") == "" || r.FormValue("InvIndex") == "" || r.FormValue("InvSeedPwd") == "" || r.FormValue("RecSeedPwd") == "" {
+			log.Println("missing params")
+			errorHandler(w, r, http.StatusNotFound)
+		}
+
+		// TODO: change that this is hardcoded, there must be a nicer way to do this
+		// maybe read from the seed and try to decrypt?
+		issuerSeed := "SBBYVEI4YNKZANRQEFH35U5GPEJ27MBLL7XHEKX5VC75QLJZWAXGX36Y"
+		issuerPk := "GAEY5TVFYWBIIHF7PQCQVNIFTNIF7QSG4IH27HRW3DH476RI4NA2BPV3"
+		_, err = xlm.GetNativeBalance(issuerPk)
+		if err != nil {
+			err = xlm.GetXLM(issuerPk)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		invAmount := r.FormValue("InvestmentAmount")
+		bondIndex := utils.StoI(r.FormValue("BondIndex"))
+		invIndex := utils.StoI(r.FormValue("InvIndex"))
+		invSeedPwd := r.FormValue("InvSeedPwd")
+		recSeedPwd := r.FormValue("RecSeedPwd")
+
+		iBond, err = database.RetrieveBond(bondIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+		iRec, err := database.RetrieveRecipient(iBond.RecipientIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// pass the investor index, pk and seed
+		iInv, err := database.RetrieveInvestor(invIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = xlm.GetNativeBalance(iInv.U.PublicKey) // get testnet funds if their account is new
+		if err != nil {
+			err = xlm.GetXLM(iInv.U.PublicKey)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+		_, err = xlm.GetNativeBalance(iRec.U.PublicKey) // get testnet funds if their account is new
+		if err != nil {
+			err = xlm.GetXLM(iRec.U.PublicKey)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		invSeed, err := iInv.U.GetSeed(invSeedPwd)
+		if err != nil {
+			log.Println("Error while getting seed, inv")
+			log.Fatal(err)
+		}
+		recSeed, err := iRec.U.GetSeed(recSeedPwd)
+		if err != nil {
+			log.Println("Error while getting seed, rec")
+			log.Fatal(err)
+		}
+
+		err = iBond.InvestInProject(issuerPk, issuerSeed, &iInv, &iRec, invAmount, invSeed, recSeed)
+		if err != nil {
+			log.Println(err)
+		}
+		log.Println("UPDATED BOND: ", iBond)
+		bondJson, err := json.Marshal(iBond)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		WriteToHandler(w, bondJson)
+	})
+}
+
+func getBondDetails() {
+	http.HandleFunc("/bond/detail", func(w http.ResponseWriter, r *http.Request) {
+		// get the details of a specific bond by key
+		if r.URL.Query()["index"] == nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		uKey := utils.StoI(r.URL.Query()["index"][0])
+		bond, err := database.RetrieveBond(uKey)
+		if err != nil {
+			log.Println(err)
+		}
+		bondJson, err := json.Marshal(bond)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		WriteToHandler(w, bondJson)
+	})
+}

--- a/rpc/bonds.go
+++ b/rpc/bonds.go
@@ -103,7 +103,7 @@ func InvestInBond() {
 			log.Fatal(err)
 		}
 
-		err = iBond.InvestInProject(issuerPk, issuerSeed, &iInv, &iRec, invAmount, invSeed, recSeed)
+		err = iBond.Invest(issuerPk, issuerSeed, &iInv, &iRec, invAmount, invSeed, recSeed)
 		if err != nil {
 			log.Println(err)
 		}

--- a/rpc/coops.go
+++ b/rpc/coops.go
@@ -1,0 +1,107 @@
+package rpc
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	database "github.com/OpenFinancing/openfinancing/database"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	xlm "github.com/OpenFinancing/openfinancing/xlm"
+)
+
+func setupCoopRPCs() {
+	getCoopDetails()
+	InvestInCoop()
+}
+
+func getCoopDetails() {
+	http.HandleFunc("/coop/get", func(w http.ResponseWriter, r *http.Request) {
+		checkOrigin(w, r)
+		checkGet(w, r)
+		// get the details of a specific bond by key
+		if r.URL.Query()["index"] == nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		uKey := utils.StoI(r.URL.Query()["index"][0])
+		bond, err := database.RetrieveCoop(uKey)
+		if err != nil {
+			log.Println(err)
+		}
+		bondJson, err := json.Marshal(bond)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		WriteToHandler(w, bondJson)
+	})
+}
+
+// curl request attached for convenience
+// curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -H "Origin: localhost" -H "Cache-Control: no-cache" -d 'MonthlyPayment=1000&CoopIndex=1&InvIndex=2&InvSeedPwd=x' "http://localhost:8080/coop/invest"
+func InvestInCoop() {
+	http.HandleFunc("/coop/invest", func(w http.ResponseWriter, r *http.Request) {
+		checkOrigin(w, r)
+		checkPost(w, r)
+		var err error
+		var iCoop database.Coop
+		// need to receive a whole lot of parameters here
+		// need the bond index passed so that we can retrieve the bond easily
+		if r.FormValue("MonthlyPayment") == "" || r.FormValue("CoopIndex") == "" || r.FormValue("InvIndex") == "" || r.FormValue("InvSeedPwd") == ""  {
+			log.Println("missing params")
+			errorHandler(w, r, http.StatusNotFound)
+		}
+
+		// TODO: change that this is hardcoded, there must be a nicer way to do this
+		// maybe read from the seed and try to decrypt?
+		issuerSeed := "SBBYVEI4YNKZANRQEFH35U5GPEJ27MBLL7XHEKX5VC75QLJZWAXGX36Y"
+		issuerPk := "GAEY5TVFYWBIIHF7PQCQVNIFTNIF7QSG4IH27HRW3DH476RI4NA2BPV3"
+		_, err = xlm.GetNativeBalance(issuerPk)
+		if err != nil {
+			err = xlm.GetXLM(issuerPk)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		invAmount := r.FormValue("MonthlyPayment")
+		CoopIndex := utils.StoI(r.FormValue("CoopIndex"))
+		invIndex := utils.StoI(r.FormValue("InvIndex"))
+		invSeedPwd := r.FormValue("InvSeedPwd")
+
+		iCoop, err = database.RetrieveCoop(CoopIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// pass the investor index, pk and seed
+		iInv, err := database.RetrieveInvestor(invIndex)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = xlm.GetNativeBalance(iInv.U.PublicKey) // get testnet funds if their account is new
+		if err != nil {
+			err = xlm.GetXLM(iInv.U.PublicKey)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
+		invSeed, err := iInv.U.GetSeed(invSeedPwd)
+		if err != nil {
+			log.Println("Error while getting seed, inv")
+			log.Fatal(err)
+		}
+		err = iCoop.Invest(issuerPk, issuerSeed, &iInv, invAmount, invSeed)
+		if err != nil {
+			log.Println(err)
+		}
+		log.Println("UPDATED BOND: ", iCoop)
+		bondJson, err := json.Marshal(iCoop)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		WriteToHandler(w, bondJson)
+	})
+}

--- a/rpc/projects.go
+++ b/rpc/projects.go
@@ -114,13 +114,11 @@ func getProject() {
 	http.HandleFunc("/project/get", func(w http.ResponseWriter, r *http.Request) {
 		checkOrigin(w, r)
 		checkGet(w, r)
-		URLPath := r.URL.Path
-		// so we now have the URL path
-		// slice "/project/" off from the URLPath
-		keyS := URLPath[7:]
-		// we now need to get the project corresponding to keyS
-		// the rpc accepts the key as int though, so string -> int
-		uKey := utils.StoI(keyS)
+		if r.URL.Query()["index"] == nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		uKey := utils.StoI(r.URL.Query()["index"][0])
 		contract, err := database.RetrieveProject(uKey)
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -113,6 +113,7 @@ func StartServer(port string) {
 	setupRecipientRPCs()
 	// setup recipient related RPCs
 	setupBondRPCs()
+	setupCoopRPCs()
 	portString := ":" + port // weird construction, but this should work
 	log.Fatal(http.ListenAndServe(portString, nil))
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -112,6 +112,7 @@ func StartServer(port string) {
 	// setup investor related RPCs
 	setupRecipientRPCs()
 	// setup recipient related RPCs
+	setupBondRPCs()
 	portString := ":" + port // weird construction, but this should work
 	log.Fatal(http.ListenAndServe(portString, nil))
 }

--- a/testdata.go
+++ b/testdata.go
@@ -15,7 +15,6 @@ func InsertDummyData() error {
 	var contract1 database.Project
 	var contract2 database.Project
 	var contract3 database.Project
-
 	var rec database.Recipient
 	allRecs, err := database.RetrieveAllRecipients()
 	if err != nil {
@@ -47,6 +46,13 @@ func InsertDummyData() error {
 			log.Fatal(err)
 		}
 	}
+
+	_, err = database.NewBond("Dec 21 2049", "Maturation Rights Link", "Security Type", 5.4, "AAA", "Bond Issuer", "underwriter.com",
+		100000, "Instrument Type", 100, "No Fed tax for 10 years", 1)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// NewOriginator(uname string, pwd string, Name string, Address string, Description string)
 	newOriginator, err := database.NewOriginator("john", "p", "x", "John Doe", "14 ABC Street London", "This is a sample originator")
 	if err != nil {

--- a/testdata.go
+++ b/testdata.go
@@ -53,6 +53,18 @@ func InsertDummyData() error {
 		log.Fatal(err)
 	}
 
+	// newParams(mdate string, mrights string, stype string, intrate float64, rating string, bIssuer string, uWriter string
+	// unitCost float64, itype string, nUnits int, tax string
+	coop, err := database.NewCoop("Dec 21 2049", "Maturation Rights Link", "Security Type", 5.4, "AAA", "Bond Issuer", "underwriter.com",
+		100000, "Type of Unit", 1000)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = database.RetrieveCoop(coop.Params.Index)
+	if err != nil {
+		log.Fatal(err)
+	}
 	// NewOriginator(uname string, pwd string, Name string, Address string, Description string)
 	newOriginator, err := database.NewOriginator("john", "p", "x", "John Doe", "14 ABC Street London", "This is a sample originator")
 	if err != nil {


### PR DESCRIPTION
This PR marks the first change between opensolar and openfinancing. This adds the RPC routes for the bond and coop structures along with a retrieve route. It also populates a dummy entry in the database which we can use to test. Since a Frontend UI is being developed, there will be no Cli interface for these specific routes.