### PR TITLE
Change Function Names and Architecture

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -10,11 +10,11 @@ import (
 // For more info about Stellar costs see: https://www.stellar.org/developers/guides/concepts/accounts.html
 var DonateBalance = "10"                                                             // we send this amount free to invesotrs who signup on our platform to enable them to have trustlines. Maybe we should have a payment provider and take money from them?
 var StablecoinTrustLimit = "100000"                                                  // the maximum limit that the investor trusts the stablecoin issuer for
-var INVAssetPrefix = "BondTokens_"                                                   // the prefix that will be hashed to give an investor AssetID
+var InvestorAssetPrefix = "BondTokens_"                                              // the prefix that will be hashed to give an investor AssetID
 var BondAssetPrefix = "BondTokens_"                                                  // the prefix that will be hashed to give a bond asset
 var CoopAssetPrefix = "CoopAsset_"                                                   // the prefix that will be hashed to give the cooperative asset
-var DEBAssetPrefix = "DEBTokens_"                                                    // the prefix that will be hashed to give a recipient AssetID
-var PBAssetPrefix = "PBTokens_"                                                      // the prefix that will be hashed to give a payback AssetID
+var DebtAssetPrefix = "DEBTokens_"                                                   // the prefix that will be hashed to give a recipient AssetID
+var PaybackAssetPrefix = "PBTokens_"                                                 // the prefix that will be hashed to give a payback AssetID
 var HomeDir = os.Getenv("HOME") + "/.openfinancing"                                  // home directory where we store the platform seed
 var PlatformSeedFile = HomeDir + "/platformseed.hex"                                 // the path where the platform's seed is stored
 var StableCoinSeedFile = HomeDir + "/stablecoinseed.hex"                             // the path where the stablecoin's seed is stored

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -61,7 +61,7 @@ func TestDb(t *testing.T) {
 	}
 	_, err = RetrieveRecipient(1)
 	if err == nil {
-		t.Fatalf("Able to retrieve all recipients in database with wrong path")
+		t.Fatalf("Able to retrieve recipient in database with wrong path")
 	}
 	user, err := NewUser("user1", "blah", "blah", "User1")
 	if err == nil {
@@ -193,13 +193,13 @@ func TestDb(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tmpinv, err := RetrieveInvestor(1000)
-	if tmpinv.U.Index != 0 {
+	_, err = RetrieveInvestor(1000)
+	if err == nil {
 		t.Fatalf("Investor shouldn't exist, but does, quitting!")
 	}
 
-	tmprec, err := RetrieveRecipient(1000)
-	if tmprec.U.Index != 0 {
+	_, err = RetrieveRecipient(1000)
+	if err == nil {
 		t.Fatalf("Investor shouldn't exist, but does, quitting!")
 	}
 

--- a/database/recipient.go
+++ b/database/recipient.go
@@ -4,6 +4,7 @@ package database
 // the struct itself.
 import (
 	"encoding/json"
+	"fmt"
 
 	utils "github.com/OpenFinancing/openfinancing/utils"
 	xlm "github.com/OpenFinancing/openfinancing/xlm"
@@ -103,7 +104,8 @@ func RetrieveRecipient(key int) (Recipient, error) {
 		b := tx.Bucket(RecipientBucket)
 		x := b.Get(utils.ItoB(key))
 		if x == nil {
-			return nil
+			// there is no key with the specific details
+			return fmt.Errorf("Recipient not found!")
 		}
 		return json.Unmarshal(x, &inv)
 	})
@@ -119,11 +121,9 @@ func ValidateRecipient(name string, pwhash string) (Recipient, error) {
 	return RetrieveRecipient(user.Index)
 }
 
-// SendAssetToIssuer sends back assets fromn an asset holder to the issuer of the asset.
+// SendAssetToIssuer sends back assets from an asset holder to the issuer of the asset.
 func (a *Recipient) SendAssetToIssuer(assetName string, issuerPubkey string, amount string, seed string) (int32, string, error) {
 	// SendAssetToIssuer is FROM recipient / investor to issuer
-	// TODO: the platform / issuer doesn't send back the PBToken since PBTOkens are
-	// disabled as of now, can add back in later if needed.
 	paymentTx, err := build.Transaction(
 		build.SourceAccount{a.U.PublicKey},
 		build.TestNetwork,

--- a/helpers.go
+++ b/helpers.go
@@ -194,7 +194,7 @@ func OriginContractPrompt(contractor *solar.Entity) error {
 	if err != nil {
 		return err
 	}
-	originContract, err := contractor.OriginContract(panelSize, totalValue, location, years, metadata, recIndex)
+	originContract, err := contractor.Originate(panelSize, totalValue, location, years, metadata, recIndex)
 	if err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func ProposeContractPrompt(contractor *solar.Entity) error {
 	if err != nil {
 		return err
 	}
-	originContract, err := contractor.ProposeContract(panelSize, totalValue, location, years, metadata, recIndex, contractIndex)
+	originContract, err := contractor.Propose(panelSize, totalValue, location, years, metadata, recIndex, contractIndex)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func ProposeContractPrompt(contractor *solar.Entity) error {
 
 func Stage3ProjectsDisplayPrompt() {
 	fmt.Println("------------LIST OF ALL AVAILABLE PROJECTS------------")
-	allProjects, err := solar.RetrieveProjects(solar.FinalizedProject)
+	allProjects, err := solar.RetrieveProjectsAtStage(solar.FinalizedProject)
 	if err != nil {
 		log.Println("Error retrieving all projects from the database")
 	} else {
@@ -265,7 +265,7 @@ func Stage3ProjectsDisplayPrompt() {
 
 func DisplayOriginProjects() {
 	fmt.Println("PRINTING ALL ORIGINATED PROJECTS: ")
-	x, err := solar.RetrieveProjects(solar.OriginProject)
+	x, err := solar.RetrieveProjectsAtStage(solar.OriginProject)
 	if err != nil {
 		log.Println(err)
 	} else {

--- a/platforms/bonds/bond.go
+++ b/platforms/bonds/bond.go
@@ -148,11 +148,11 @@ func (a *ConstructionBond) Invest(issuerPublicKey string, issuerSeed string, inv
 	}
 	assetName := assets.AssetID(a.Params.MaturationDate + a.Params.SecurityType + a.Params.Rating + a.Params.BondIssuer) // get a unique assetID
 
-	if a.Params.INVAssetCode == "" {
+	if a.Params.InvestorAssetCode == "" {
 		// this person is the first investor, set the investor token name
-		INVAssetCode := assets.AssetID(consts.BondAssetPrefix + assetName)
-		a.Params.INVAssetCode = INVAssetCode                  // set the investeor code
-		_ = assets.CreateAsset(INVAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
+		InvestorAssetCode := assets.AssetID(consts.BondAssetPrefix + assetName)
+		a.Params.InvestorAssetCode = InvestorAssetCode             // set the investeor code
+		_ = assets.CreateAsset(InvestorAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
 	}
 	/*
 		dont check stableUSD balance for now
@@ -162,7 +162,7 @@ func (a *ConstructionBond) Invest(issuerPublicKey string, issuerSeed string, inv
 		}
 	*/
 	var INVAsset build.Asset
-	INVAsset.Code = a.Params.INVAssetCode
+	INVAsset.Code = a.Params.InvestorAssetCode
 	INVAsset.Issuer = issuerPublicKey
 	// make in v estor trust the asset that we provide
 	txHash, err := assets.TrustAsset(INVAsset, utils.FtoS(a.CostOfUnit*float64(a.NoOfUnits)), investor.U.PublicKey, investorSeed)
@@ -180,7 +180,7 @@ func (a *ConstructionBond) Invest(issuerPublicKey string, issuerSeed string, inv
 	// investor asset sent, update a.Params's BalLeft
 	a.AmountRaised += float64(investmentAmount)
 	investor.AmountInvested += float64(investmentAmount)
-	investor.InvestedBonds = append(investor.InvestedBonds, a.Params.INVAssetCode)
+	investor.InvestedBonds = append(investor.InvestedBonds, a.Params.InvestorAssetCode)
 	err = investor.Save() // save investor creds now that we're done
 	if err != nil {
 		return err

--- a/platforms/bonds/coop.go
+++ b/platforms/bonds/coop.go
@@ -124,11 +124,11 @@ func (a *Coop) Invest(issuerPublicKey string, issuerSeed string, investor *datab
 	}
 	assetName := assets.AssetID(a.Params.MaturationDate + a.Params.SecurityType + a.Params.Rating + a.Params.BondIssuer) // get a unique assetID
 
-	if a.Params.INVAssetCode == "" {
+	if a.Params.InvestorAssetCode == "" {
 		// this person is the first investor, set the investor token name
-		INVAssetCode := assets.AssetID(consts.CoopAssetPrefix + assetName)
-		a.Params.INVAssetCode = INVAssetCode                  // set the investeor code
-		_ = assets.CreateAsset(INVAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
+		InvestorAssetCode := assets.AssetID(consts.CoopAssetPrefix + assetName)
+		a.Params.InvestorAssetCode = InvestorAssetCode             // set the investeor code
+		_ = assets.CreateAsset(InvestorAssetCode, issuerPublicKey) // create the asset itself, since it would not have bene created earlier
 	}
 	/*
 		dont check stableUSD balance for now
@@ -138,7 +138,7 @@ func (a *Coop) Invest(issuerPublicKey string, issuerSeed string, investor *datab
 		}
 	*/
 	var INVAsset build.Asset
-	INVAsset.Code = a.Params.INVAssetCode
+	INVAsset.Code = a.Params.InvestorAssetCode
 	INVAsset.Issuer = issuerPublicKey
 	// make in v estor trust the asset that we provide
 	txHash, err := assets.TrustAsset(INVAsset, utils.FtoS(a.TotalAmount), investor.U.PublicKey, investorSeed)
@@ -156,7 +156,7 @@ func (a *Coop) Invest(issuerPublicKey string, issuerSeed string, investor *datab
 	// investor asset sent, update a.Params's BalLeft
 	a.UnitsSold += 1
 	investor.AmountInvested += float64(investmentAmount)
-	investor.InvestedCoops = append(investor.InvestedCoops, a.Params.INVAssetCode)
+	investor.InvestedCoops = append(investor.InvestedCoops, a.Params.InvestorAssetCode)
 	err = investor.Save() // save investor creds now that we're done
 	if err != nil {
 		return err

--- a/platforms/bonds/params.go
+++ b/platforms/bonds/params.go
@@ -4,17 +4,17 @@ package bonds
 // the idea is to ahve a common set of params for each platform and then each model
 // could boorow this base params and build upon it as desired.
 type BondCoopParams struct {
-	Index          int
-	MaturationDate string
-	MemberRights   string
-	SecurityType   string
-	InterestRate   float64
-	Rating         string
-	BondIssuer     string
-	Underwriter    string
-	DateInitiated  string // date the project was created
-	INVAssetCode   string
-	Title          string
-	Description    string
-	Location       string
+	Index             int
+	MaturationDate    string
+	MemberRights      string
+	SecurityType      string
+	InterestRate      float64
+	Rating            string
+	BondIssuer        string
+	Underwriter       string
+	DateInitiated     string // date the project was created
+	InvestorAssetCode string
+	Title             string
+	Description       string
+	Location          string
 }

--- a/platforms/solar/auctions.go
+++ b/platforms/solar/auctions.go
@@ -27,15 +27,15 @@ type ContractAuction struct {
 	// contractors who want to get this price. This is a blind auction and the
 	// choosing criteria is just price for now.
 	// TODO: decide this criteria
-	AllContracts    []SolarProject
+	AllContracts    []Project
 	AllContractors  []Entity
-	WinningContract SolarProject // do we need this?
+	WinningContract Project // do we need this?
 }
 
 // auctions contains stuff related to choosing the best contract and potentially
 // future auction logic that might need to be housed here
-func SelectContractByPrice(arr []SolarProject) (SolarProject, error) {
-	var a SolarProject
+func SelectContractByPrice(arr []Project) (Project, error) {
+	var a Project
 	if len(arr) == 0 {
 		return a, fmt.Errorf("Empty array passed!")
 	}
@@ -50,8 +50,8 @@ func SelectContractByPrice(arr []SolarProject) (SolarProject, error) {
 	return a, nil
 }
 
-func SelectContractByTime(arr []SolarProject) (SolarProject, error) {
-	var a SolarProject
+func SelectContractByTime(arr []Project) (Project, error) {
+	var a Project
 	if len(arr) == 0 {
 		return a, fmt.Errorf("Empty array passed!")
 	}

--- a/platforms/solar/contractor.go
+++ b/platforms/solar/contractor.go
@@ -2,6 +2,7 @@ package solar
 
 import (
 	"fmt"
+
 	database "github.com/OpenFinancing/openfinancing/database"
 	utils "github.com/OpenFinancing/openfinancing/utils"
 )
@@ -17,11 +18,11 @@ import (
 // An alternative is to have a reputation system for contractors.
 
 //TODO: A given Contractor right now is allowed only for one final bid for blind
-// auction advantages (i.e. no price disovcery, etc). If we want to change this, we must
+// auction advantages (i.e. no price discovery, etc). If we want to change this, we must
 // Also, have some kind of deposit for Contractors (5% or something) so that they
 // don't go back on their investment and slash their ivnestment by 10% if this happens
 // and distribute that amount to the recipient directly and reduce everyone's bids
-// by that amount to account for the change in underlying SolarProject
+// by that amount to account for the change in underlying Project
 // also, a given Contractor right now is allowed only for one final bid for blind
 // auction advantages (no price disvocery, etc). If we want to change this, we must
 // have an auction handler that will take care of this.
@@ -30,11 +31,11 @@ import (
 func NewContractor(uname string, pwd string, seedpwd string, Name string, Address string, Description string) (Entity, error) {
 	// Create a new entity with the boolean of 'contractor' set to 'true.' This is done just by passing the string "contractor"
 	// TODO: Consider other specific information needed for contractors, other than the ones set for users and entities. It can go here, or set as a separate struct.
-	return NewEntity(uname, pwd, seedpwd, Name, Address, Description, "contractor")
+	return newEntity(uname, pwd, seedpwd, Name, Address, Description, "contractor")
 }
 
-func (contractor *Entity) ProposeContract(panelSize string, totalValue int, location string, years int, metadata string, recIndex int, projectIndex int) (SolarProject, error) {
-	var pc SolarProject
+func (contractor *Entity) Propose(panelSize string, totalValue int, location string, years int, metadata string, recIndex int, projectIndex int) (Project, error) {
+	var pc Project
 	var err error
 
 	// for this, create a new contract and store in the contracts db. We are sorting
@@ -51,10 +52,10 @@ func (contractor *Entity) ProposeContract(panelSize string, totalValue int, loca
 	pc.Params.Metadata = metadata
 	pc.Params.DateInitiated = utils.Timestamp()
 	iRecipient, err := database.RetrieveRecipient(recIndex)
-	if iRecipient.U.Index == 0 {
-		return pc, fmt.Errorf("Recipient not found!")
+	if err != nil {
+		return pc, err
 	}
-	pc.Params.ProjectRecipient = iRecipient
+	pc.ProjectRecipient = iRecipient
 	pc.Stage = 2 // 2 since we need to filter this out while retrieving the propsoed contracts
 	pc.Contractor = *contractor
 	// instead of storing in this proposedcontracts slice, store it as a project, but not a contract and retrieve by stage

--- a/platforms/solar/entities.go
+++ b/platforms/solar/entities.go
@@ -54,49 +54,19 @@ type Entity struct {
 	// A Guarantor is someone who can vouch for the recipient and fill in for them
 	// in case they default on payment. They can c harge a fee and this must be
 	// put inside the contract itself.
-	PastContracts []SolarProject
+	PastContracts []Project
 	// list of all the contracts that the contractor has won in the past
-	ProposedContracts []SolarProject
+	ProposedContracts []Project
 	// the Originator proposes a contract which will then be taken up
 	// by a contractor, who publishes his own copy of the proposed contract
 	// which will be the set of contracts that will be sent to auction
-	PresentContracts []SolarProject
+	PresentContracts []Project
 	// list of all contracts that the contractor is presently undertaking1
 	PastFeedback []Feedback
 	// feedback received on the contractor from parties involved in the past
 	// What kind of proof do we want from the company? KYC?
 	// maybe we could have a photo op like exchanges do these days, with the owner
 	// holding up his drivers' license or similar
-}
-
-func newEntityHelper(uname string, pwd string, seedpwd string, Name string, Address string, Description string, role string) (Entity, error) {
-	// call this after the user has failled in username and password. Store hashed password
-	// in the database
-	var a Entity
-	var err error
-	a.U, err = database.NewUser(uname, pwd, seedpwd, Name)
-	if err != nil {
-		return a, err
-	}
-	// set all auto fields above
-	a.U.Address = Address
-	a.U.Description = Description
-	// insertion into the database will be a separate handler, pass this Entity there
-	switch role {
-	case "contractor":
-		a.Contractor = true
-	case "developer":
-		a.Developer = true
-	case "originator":
-		a.Originator = true
-	case "guarantor":
-		a.Guarantor = true
-	default:
-		return a, fmt.Errorf("invalid entity passed!")
-		// nothing, since only we call this function internally, this shouldn't arrive here
-	}
-	err = a.Save()
-	return a, err
 }
 
 func (a *Entity) Save() error {
@@ -117,23 +87,8 @@ func (a *Entity) Save() error {
 	return err
 }
 
-func NewEntity(uname string, pwd string, seedpwd string, Name string, Address string, Description string, role string) (Entity, error) {
-	var dummy Entity
-	switch role {
-	case "originator":
-		return newEntityHelper(uname, pwd, seedpwd, Name, Address, Description, "originator")
-	case "developer":
-		return newEntityHelper(uname, pwd, seedpwd, Name, Address, Description, "developer")
-	case "contractor":
-		return newEntityHelper(uname, pwd, seedpwd, Name, Address, Description, "contractor")
-	case "guarantor":
-		return newEntityHelper(uname, pwd, seedpwd, Name, Address, Description, "guarantor")
-	}
-	return dummy, fmt.Errorf("Invalid entity passed, check again!")
-}
-
 // gets all the proposed contracts for a particular recipient
-func RetrieveAllContractEntities(role string) ([]Entity, error) {
+func RetrieveAllEntities(role string) ([]Entity, error) {
 	var arr []Entity
 	temp, err := database.RetrieveAllUsers()
 	if err != nil {
@@ -241,5 +196,32 @@ func SearchForEntity(name string, pwhash string) (Entity, error) {
 		}
 		return fmt.Errorf("Not Found")
 	})
+	return a, err
+}
+
+func newEntity(uname string, pwd string, seedpwd string, Name string, Address string, Description string, role string) (Entity, error) {
+	var a Entity
+	var err error
+	a.U, err = database.NewUser(uname, pwd, seedpwd, Name)
+	if err != nil {
+		return a, err
+	}
+	// set all auto fields above
+	a.U.Address = Address
+	a.U.Description = Description
+	// insertion into the database will be a separate handler, pass this Entity there
+	switch role {
+	case "contractor":
+		a.Contractor = true
+	case "developer":
+		a.Developer = true
+	case "originator":
+		a.Originator = true
+	case "guarantor":
+		a.Guarantor = true
+	default:
+		return a, fmt.Errorf("invalid entity passed!")
+	}
+	err = a.Save()
 	return a, err
 }

--- a/platforms/solar/feedback.go
+++ b/platforms/solar/feedback.go
@@ -16,6 +16,6 @@ type Feedback struct {
 	// regarding whom is this feedback about
 	Date string
 	// time at which this feedback was written
-	RelatedContract []SolarProject
+	RelatedContract []Project
 	// the contract regarding which this feedback is directed at
 }

--- a/platforms/solar/invest.go
+++ b/platforms/solar/invest.go
@@ -11,6 +11,11 @@ import (
 	"github.com/stellar/go/build"
 )
 
+// this file does not contain any tests associated with it right now. In the future,
+// once we have a robust frontend, we can modify the CLI interface to act as a test
+// for this file
+
+// InvestInProject invests in a particular solar project given required parameters
 func InvestInProject(projIndex int, issuerPubkey string, issuerSeed string, invIndex int, recpIndex int, invAmountS string, invSeed string, recpSeed string) (Project, error) {
 	var err error
 

--- a/platforms/solar/invest.go
+++ b/platforms/solar/invest.go
@@ -1,0 +1,141 @@
+package solar
+
+import (
+	"fmt"
+	"log"
+
+	assets "github.com/OpenFinancing/openfinancing/assets"
+	consts "github.com/OpenFinancing/openfinancing/consts"
+	database "github.com/OpenFinancing/openfinancing/database"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	"github.com/stellar/go/build"
+)
+
+func InvestInProject(projIndex int, issuerPubkey string, issuerSeed string, invIndex int, recpIndex int, invAmountS string, invSeed string, recpSeed string) (Project, error) {
+	var err error
+
+	project, err := RetrieveProject(projIndex)
+	if err != nil {
+		return project, err
+	}
+	// invest only in integer values as of now, TODO: change to float
+	invAmount := utils.StoI(invAmountS)
+	// check if investment amount is greater than or equal to the project requirements
+	if invAmount > project.Params.TotalValue-project.Params.MoneyRaised {
+		fmt.Println("User is trying to invest more than what is needed, print and exit")
+		return project, fmt.Errorf("User is trying to invest more than what is needed, print and exit")
+	}
+	investor, err := database.RetrieveInvestor(invIndex)
+	if err != nil {
+		return project, err
+	}
+	// we should check here whether the investor has enough USDTokens in project to be
+	// able to ivnest in the asset
+	if !investor.CanInvest(investor.U.PublicKey, invAmountS) {
+		log.Println("Investor has less balance than what is required to ivnest in this asset")
+		return project, err
+	}
+	recipient, err := database.RetrieveRecipient(recpIndex)
+	if err != nil {
+		return project, err
+	}
+
+	// user has decided to invest in a part of the project (don't know if full yet)
+	// so if there has been no token codes assigned yet, we need to create them and
+	// assign them here
+	// you can retrieve these anywhere since the metadata will most likely be unique
+	assetName := assets.AssetID(project.Params.Metadata)
+	if project.Params.InvestorAssetCode == "" {
+		// this person is the first investor, set the investor token name
+		project.Params.InvestorAssetCode = assets.AssetID(consts.InvestorAssetPrefix + assetName) // set the investeor code
+		_ = assets.CreateAsset(project.Params.InvestorAssetCode, issuerPubkey)                    // create the asset itself, since it would not have bene created earlier
+	}
+	var InvAsset build.Asset
+	InvAsset.Code = project.Params.InvestorAssetCode
+	InvAsset.Issuer = issuerPubkey
+	// InvAsset is not a native token, so don't set native to true
+	// make investor trust the asset, trustlimit is upto the value of the project
+	txHash, err := assets.TrustAsset(InvAsset, utils.ItoS(project.Params.TotalValue), investor.U.PublicKey, invSeed)
+	if err != nil {
+		return project, err
+	}
+	log.Println("Investor trusted asset: ", InvAsset.Code, " tx hash: ", txHash)
+	_, txHash, err = assets.SendAssetFromIssuer(InvAsset.Code, investor.U.PublicKey, invAmountS, issuerSeed, issuerPubkey)
+	if err != nil {
+		return project, err
+	}
+	log.Printf("Sent InvAsset %s to investor %s with txhash %s", InvAsset.Code, investor.U.PublicKey, txHash)
+	// investor asset sent, update project.Params's BalLeft
+	project.Params.MoneyRaised += invAmount
+	fmt.Println("Updating investor to handle invested amounts and assets")
+	investor.AmountInvested += float64(invAmount)
+	investor.InvestedSolarProjects = append(investor.InvestedSolarProjects, project.Params.DebtAssetCode)
+	err = investor.Save() // save investor creds now that we're done
+	if err != nil {
+		return project, err
+	}
+	fmt.Println("Updated investor database")
+	// append the investor class to the list of project investors
+	// if the same investor has invested twice, he will appear twice
+	// can be resolved on the UI side by requiring unique, so not doing that here
+	project.ProjectInvestors = append(project.ProjectInvestors, investor)
+	if project.Params.MoneyRaised == project.Params.TotalValue {
+		// this project covers up the amount nedeed for the project, so set the DebtAssetCode
+		// and PaybackAssetCodes, generate them and give to the recipient
+		project.Params.DebtAssetCode = assets.AssetID(consts.DebtAssetPrefix + assetName)
+		project.Params.PaybackAssetCode = assets.AssetID(consts.PaybackAssetPrefix + assetName)
+		DebtAsset := assets.CreateAsset(project.Params.DebtAssetCode, issuerPubkey)
+		PaybackAsset := assets.CreateAsset(project.Params.PaybackAssetCode, issuerPubkey)
+		// and the school needs to trust me only for paybackTokens amount of PB tokens
+		pbAmtTrust := utils.ItoS(project.Params.Years * 12 * 2) // two way exchange possible, to account for errors
+		txHash, err = assets.TrustAsset(PaybackAsset, pbAmtTrust, recipient.U.PublicKey, recpSeed)
+		if err != nil {
+			return project, err
+		}
+		log.Println("Recipient Trusted Payback asset: ", PaybackAsset.Code, " tx hash: ", txHash)
+		txHash, err = assets.TrustAsset(DebtAsset, utils.ItoS(project.Params.TotalValue*2), recipient.U.PublicKey, recpSeed) // since debt = invested amount
+		// *2 is for sending the amount back
+		if err != nil {
+			return project, err
+		}
+		log.Println("Recipient Trusted Debt asset: ", DebtAsset.Code, " tx hash: ", txHash)
+		_, txHash, err = assets.SendAssetFromIssuer(project.Params.DebtAssetCode, recipient.U.PublicKey, utils.ItoS(project.Params.TotalValue), issuerSeed, issuerPubkey) // same amount as debt
+		if err != nil {
+			return project, err
+		}
+		log.Printf("Sent DebtAsset to recipient %s with txhash %s", recipient.U.PublicKey, txHash)
+		project.Params.BalLeft = float64(project.Params.TotalValue)
+		recipient.ReceivedSolarProjects = append(recipient.ReceivedSolarProjects, project.Params.DebtAssetCode)
+		project.ProjectRecipient = recipient // need to udpate project.Params each time recipient is mutated
+		// only here does the recipient part change, so update it only here
+		// TODO: keep note of who all invested in this asset (even though it should be
+		// easy to get that from the blockchain)
+		if project.Params.DebtAssetCode == "" {
+			return project, fmt.Errorf("Empty debt asset code")
+		}
+		err = recipient.Save()
+		if err != nil {
+			return project, err
+		}
+		project.Stage = FundedProject // set funded project stage
+		err = project.Save()
+		if err != nil {
+			log.Println("Couldn't insert project")
+			return project, err
+		}
+		fmt.Println("Updated recipient bucket")
+		return project, nil
+	}
+	// update the project finally now that we have updated other databases
+	err = project.Save()
+	return project, err
+}
+
+// sendPaybackAsset sends back the solar pb asset from the issuer to the recipient
+func sendPaybackAsset(project Project, destination string, amount string, platformSeed string, platformPubkey string) error {
+	// need to calculate how much PaybackAsset we need to send back.
+	amountS := project.CalculatePayback(amount)
+	_, txHash, err := assets.SendAssetFromIssuer(project.Params.PaybackAssetCode, destination, amountS, platformSeed, platformPubkey)
+	log.Println("TXHASH for payback is: ", txHash)
+	return err
+}

--- a/platforms/solar/originator.go
+++ b/platforms/solar/originator.go
@@ -10,11 +10,12 @@ import (
 // This function is returns a new entity with the bool "originator" as true
 // TODO: Consider any other information needed for originators that should be added to the Users/Entities struct, or create a new struct altogether
 func NewOriginator(uname string, pwd string, seedpwd string, Name string, Address string, Description string) (Entity, error) {
-	return NewEntity(uname, pwd, seedpwd, Name, Address, Description, "originator")
+	return newEntity(uname, pwd, seedpwd, Name, Address, Description, "originator")
 }
 
-func (contractor *Entity) OriginContract(panelSize string, totalValue int, location string, years int, metadata string, recIndex int) (SolarProject, error) {
-	var pc SolarProject
+// Originate creates and saves a new origin contract
+func (contractor *Entity) Originate(panelSize string, totalValue int, location string, years int, metadata string, recIndex int) (Project, error) {
+	var pc Project
 	var err error
 
 	// for this, create a new  contract and store in the contracts db. Wea re sorting
@@ -31,10 +32,10 @@ func (contractor *Entity) OriginContract(panelSize string, totalValue int, locat
 	pc.Params.Metadata = metadata
 	pc.Params.DateInitiated = utils.Timestamp()
 	iRecipient, err := database.RetrieveRecipient(recIndex)
-	if iRecipient.U.Index == 0 { // recipient does not exist
-		return pc, fmt.Errorf("Recipient does not exist!")
+	if err != nil { // recipient does not exist
+		return pc, err
 	}
-	pc.Params.ProjectRecipient = iRecipient
+	pc.ProjectRecipient = iRecipient
 	pc.Stage = 0 // 0 since we need to filter this out while retrieving the propsoed contracts
 	pc.Originator = *contractor
 	// instead of storing in this proposedcontracts slice, store it as a project, but not a contract and retrieve by stage

--- a/platforms/solar/params.go
+++ b/platforms/solar/params.go
@@ -1,9 +1,6 @@
 package solar
 
-import (
-	database "github.com/OpenFinancing/openfinancing/database"
-)
-
+// TODO: add more paramters here that would help identify a given solar project
 type SolarParams struct {
 	Index int // an Index to keep quick track of how many projects exist
 
@@ -14,20 +11,16 @@ type SolarParams struct {
 	Years       int    // number of years the recipient has chosen to opt for
 	Metadata    string // any other metadata can be stored here
 
-	Votes int // the number of votes towards a proposed contract by investors
-
 	// once all funds have been raised, we need to set assetCodes
-	INVAssetCode string
-	DEBAssetCode string
-	PBAssetCode  string
+	InvestorAssetCode string
+	DebtAssetCode     string
+	PaybackAssetCode  string
 
 	BalLeft float64 // denotes the balance left to pay by the party
+	Votes   int     // the number of votes towards a proposed contract by investors
 
 	DateInitiated string // date the project was created
 	DateFunded    string // date when the project was funded
 	DateLastPaid  string // date the project was last paid
-
-	ProjectRecipient database.Recipient
-	ProjectInvestors []database.Investor // TODO: get feedback on whether this is in its right place and whether this should be moved to contract
 	// Percentage raised is not stored in the database since that can be calculated by the UI
 }

--- a/platforms/solar/solar.go
+++ b/platforms/solar/solar.go
@@ -24,40 +24,30 @@ import (
 // A legal contract should ideally be stored on ipfs and we must keep track of the
 // ipfs hash so that we can retrieve it later when required
 
-// A SolarProject is what is stored in the database and what is used by other packages
-// SolarProject imports SolarParams since having everythin inside one struct is tedious
+// A Project is what is stored in the database and what is used by other packages
+// Project imports SolarParams since having everythin inside one struct is tedious
 // and SolarParams already has lots of keys. Also, this doesn't affect the way its
 // actually stored in the database, so its a nice way to do it.
 // SolarParams is also what's needed by the assets and other stuff whereas the other fields
 // are needed in other parts, another nice distinction
-type SolarProject struct {
-	Params SolarParams // Params is the former Order struct imported into the new SolarProject structure
+type Project struct {
+	Params SolarParams // Params is the former Order struct imported into the new Project structure
 
-	Originator    Entity // a specific contract must hold the person who originated it
-	Contractor    Entity // the person with the proposed contract
-	Guarantor     Entity // the person guaranteeing the specific project in question
-	OriginatorFee int    // fee paid to the originator from the total fee of the project
-	ContractorFee int    // fee paid to the contractor from the total fee of the project
-
-	Stage float64 // the stage at which the contract is at, float due to potential support of 0.5 state changes in the future
+	Originator       Entity // a specific contract must hold the person who originated it
+	OriginatorFee    int    // fee paid to the originator from the total fee of the project
+	Contractor       Entity // the person with the proposed contract
+	ContractorFee    int    // fee paid to the contractor from the total fee of the project
+	Guarantor        Entity // the person guaranteeing the specific project in question
+	ProjectRecipient database.Recipient
+	ProjectInvestors []database.Investor
+	Stage            float64 // the stage at which the contract is at, float due to potential support of 0.5 state changes in the future
 }
 
 // so a contract's rough workflow is like
 // origincontract (0) -> approval by recipient (1) -> OpenForMoneyStage (1.5) -> ...
 // NewOriginProject returns a new project passed a project and originator to assign to
-// stage is set automatically to 1 by the call to SetOriginProject
-func NewOriginProject(project SolarParams, originator Entity) (SolarProject, error) {
-	// need variadic params to store optional stuff
-	var proposedProject SolarProject
-	proposedProject.Params = project
-	proposedProject.Originator = originator
-	proposedProject.Stage = 1
-	err := proposedProject.Save()
-	return proposedProject, err
-}
-
-// Save or Insert inserts a specific SolarProject into the database
-func (a *SolarProject) Save() error {
+// Save or Insert inserts a specific Project into the database
+func (a *Project) Save() error {
 	db, err := database.OpenDB()
 	if err != nil {
 		return err
@@ -74,10 +64,9 @@ func (a *SolarProject) Save() error {
 	return err
 }
 
-// MW: Improve the funcion names (i.e. Retrieve Project, AllProjects, Projects)
 // RetrieveProject retrieves the project with the specified index from the database
-func RetrieveProject(key int) (SolarProject, error) {
-	var inv SolarProject
+func RetrieveProject(key int) (Project, error) {
+	var inv Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return inv, err
@@ -95,8 +84,8 @@ func RetrieveProject(key int) (SolarProject, error) {
 }
 
 // RetrieveAllProjects retrieves all projects from the database
-func RetrieveAllProjects() ([]SolarProject, error) {
-	var arr []SolarProject
+func RetrieveAllProjects() ([]Project, error) {
+	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return arr, err
@@ -105,7 +94,7 @@ func RetrieveAllProjects() ([]SolarProject, error) {
 	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.ProjectsBucket)
 		for i := 1; ; i++ {
-			var rProject SolarProject
+			var rProject Project
 			x := b.Get(utils.ItoB(i))
 			if x == nil {
 				break
@@ -122,8 +111,8 @@ func RetrieveAllProjects() ([]SolarProject, error) {
 	return arr, err
 }
 
-func RetrieveProjects(stage float64) ([]SolarProject, error) {
-	var arr []SolarProject
+func RetrieveProjectsAtStage(stage float64) ([]Project, error) {
+	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return arr, err
@@ -132,7 +121,7 @@ func RetrieveProjects(stage float64) ([]SolarProject, error) {
 	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.ProjectsBucket)
 		for i := 1; ; i++ {
-			var rProject SolarProject
+			var rProject Project
 			x := b.Get(utils.ItoB(i))
 			if x == nil {
 				break
@@ -151,8 +140,8 @@ func RetrieveProjects(stage float64) ([]SolarProject, error) {
 	return arr, err
 }
 
-func RetrieveProjectsC(stage float64, index int) ([]SolarProject, error) {
-	var arr []SolarProject
+func RetrieveContractorProjects(stage float64, index int) ([]Project, error) {
+	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return arr, err
@@ -163,7 +152,7 @@ func RetrieveProjectsC(stage float64, index int) ([]SolarProject, error) {
 		// trying to retrieve a list of keys
 		b := tx.Bucket(database.ProjectsBucket)
 		for i := 1; ; i++ {
-			var rProject SolarProject
+			var rProject Project
 			x := b.Get(utils.ItoB(i))
 			if x == nil {
 				// this is where the key does not exist
@@ -187,8 +176,8 @@ func RetrieveProjectsC(stage float64, index int) ([]SolarProject, error) {
 
 // RetrieveOriginProjectsIO is used when we want to display the list of originated
 // contracts to the originator
-func RetrieveProjectsO(stage float64, index int) ([]SolarProject, error) {
-	var arr []SolarProject
+func RetrieveOriginatorProjects(stage float64, index int) ([]Project, error) {
+	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return arr, err
@@ -199,7 +188,7 @@ func RetrieveProjectsO(stage float64, index int) ([]SolarProject, error) {
 		// trying to retrieve a list of keys
 		b := tx.Bucket(database.ProjectsBucket)
 		for i := 1; ; i++ {
-			var rProject SolarProject
+			var rProject Project
 			x := b.Get(utils.ItoB(i))
 			if x == nil {
 				return nil
@@ -218,8 +207,8 @@ func RetrieveProjectsO(stage float64, index int) ([]SolarProject, error) {
 	return arr, err
 }
 
-func RetrieveProjectsR(stage float64, index int) ([]SolarProject, error) {
-	var arr []SolarProject
+func RetrieveRecipientProjects(stage float64, index int) ([]Project, error) {
+	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
 		return arr, err
@@ -230,7 +219,7 @@ func RetrieveProjectsR(stage float64, index int) ([]SolarProject, error) {
 		// trying to retrieve a list of keys
 		b := tx.Bucket(database.ProjectsBucket)
 		for i := 1; ; i++ {
-			var rProject SolarProject
+			var rProject Project
 			x := b.Get(utils.ItoB(i))
 			if x == nil {
 				return nil
@@ -239,7 +228,7 @@ func RetrieveProjectsR(stage float64, index int) ([]SolarProject, error) {
 			if err != nil {
 				return nil
 			}
-			if rProject.Stage == stage && rProject.Params.ProjectRecipient.U.Index == index {
+			if rProject.Stage == stage && rProject.ProjectRecipient.U.Index == index {
 				// return contracts which have been originated and are not final yet
 				arr = append(arr, rProject)
 			}
@@ -253,14 +242,18 @@ func RetrieveProjectsR(stage float64, index int) ([]SolarProject, error) {
 // if you already have the project and the recipient struct ready to pass.
 // this function is not used right now, but would be when we finalize the various
 // stages of a project
-func (project *SolarProject) RecipientAuthorizeContract(recipient database.Recipient) error {
-	if project.Params.ProjectRecipient.U.Name != recipient.U.Name {
+func RecipientAuthorize(projIndex int, recipient database.Recipient) error {
+	project, err := RetrieveProject(projIndex)
+	if err != nil {
+		return err
+	}
+	if project.ProjectRecipient.U.Name != recipient.U.Name {
 		// TODO: COnsider that for this authorization to happen, there could be a verification requirement (eg. that the project is relatively feasible),
 		// and that it may need several approvals for it (eg. Recipient can be two figures here —the school entity (more visible) and the department of education (more admin) who is the actual issuer)
 		return fmt.Errorf("You can't authorize a project which is not assigned to you!")
 	}
 	// set the project as both originated and ready for investors' money
-	err := project.SetOriginProject()
+	err = project.SetOriginProject()
 	if err != nil {
 		return err
 	}
@@ -271,9 +264,50 @@ func (project *SolarProject) RecipientAuthorizeContract(recipient database.Recip
 	return nil
 }
 
+func VoteTowardsProposedProject(invIndex int, votes int, projectIndex int) error {
+	inv, err := database.RetrieveInvestor(invIndex)
+	if err != nil {
+		return err
+	}
+	if votes > inv.VotingBalance {
+		return fmt.Errorf("Can't vote with an amount greater than available balance")
+	}
+	project, err := RetrieveProject(projectIndex)
+	if err != nil {
+		return err
+	}
+	if project.Stage != 2 {
+		return fmt.Errorf("You can't vote for a project with stage less than 3")
+	}
+	// we have the specific contract and need to upgrade the number of votes on this one
+	project.Params.Votes += votes
+	err = project.Save()
+	if err != nil {
+		return err
+	}
+	err = inv.DeductVotingBalance(votes)
+	if err != nil {
+		return err
+	}
+	fmt.Println("CAST VOTE TOWARDS PROJECT SUCCESSFULLY")
+	return nil
+}
+
+// stage is set automatically to 1 by the call to SetOriginProject
+// this function is used exclusively for testing
+func newOriginProject(project SolarParams, originator Entity) (Project, error) {
+	// need variadic params to store optional stuff
+	var proposedProject Project
+	proposedProject.Params = project
+	proposedProject.Originator = originator
+	proposedProject.Stage = 1
+	err := proposedProject.Save()
+	return proposedProject, err
+}
+
 // A function to find a project within an array of projects, given the key or index
-func FindInKey(key int, arr []SolarProject) (SolarProject, error) {
-	var dummy SolarProject
+func findInKey(key int, arr []Project) (Project, error) {
+	var dummy Project
 	for _, elem := range arr {
 		if elem.Params.Index == key {
 			return elem, nil
@@ -282,40 +316,10 @@ func FindInKey(key int, arr []SolarProject) (SolarProject, error) {
 	return dummy, fmt.Errorf("Not found")
 }
 
-func VoteTowardsProposedProject(a *database.Investor, votes int, index int) error {
-	// split the coting stuff into a separate function
-	// we need to go through the contractor's proposed projects to find an project
-	// with index pProjectN
-	allProposedProjects, err := RetrieveProjects(ProposedProject)
-	if err != nil {
-		return err
-	}
-	if votes > a.VotingBalance {
-		return fmt.Errorf("Can't vote with an amount greater than available balance")
-	}
-	for _, elem := range allProposedProjects {
-		if elem.Params.Index == index {
-			// we have the specific contract and need to upgrade the number of votes on this one
-			elem.Params.Votes += votes
-			err = elem.Save()
-			if err != nil {
-				return err
-			}
-			err = a.DeductVotingBalance(votes)
-			if err != nil {
-				return err
-			}
-			fmt.Println("CAST VOTE TOWARDS CONTRACT SUCCESSFULLY")
-			return nil
-		}
-	}
-	return fmt.Errorf("Index of project not found, returning")
-}
-
-func UpdateProjectSlice(a *database.Recipient, project SolarParams) error {
+func (project *Project) updateRecipient(a database.Recipient) error {
 	pos := -1
 	for i, mem := range a.ReceivedSolarProjects {
-		if mem == project.DEBAssetCode {
+		if mem == project.Params.DebtAssetCode {
 			log.Println("Rewriting the thing in our copy")
 			// rewrite the thing in memory that we have
 			pos = i
@@ -324,7 +328,7 @@ func UpdateProjectSlice(a *database.Recipient, project SolarParams) error {
 	}
 	if pos != -1 {
 		// rewrite the thing in memory
-		a.ReceivedSolarProjects[pos] = project.DEBAssetCode
+		a.ReceivedSolarProjects[pos] = project.Params.DebtAssetCode
 		err := a.Save()
 		return err
 	}

--- a/platforms/solar/solar.go
+++ b/platforms/solar/solar.go
@@ -332,5 +332,5 @@ func (project *Project) updateRecipient(a database.Recipient) error {
 		err := a.Save()
 		return err
 	}
-	return fmt.Errorf("Not found")
+	return nil
 }

--- a/platforms/solar/solar_test.go
+++ b/platforms/solar/solar_test.go
@@ -536,5 +536,10 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("not able to catch invalid entity error")
 	}
+	var recpx database.Recipient
+	err = dummy.updateRecipient(recpx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	os.Remove(os.Getenv("HOME") + "/.openfinancing/database/" + "/yol.db")
 }

--- a/platforms/solar/solar_test.go
+++ b/platforms/solar/solar_test.go
@@ -537,6 +537,7 @@ func TestDb(t *testing.T) {
 		t.Fatalf("not able to catch invalid entity error")
 	}
 	var recpx database.Recipient
+	recpx.ReceivedSolarProjects = append(recpx.ReceivedSolarProjects, dummy.Params.DebtAssetCode)
 	err = dummy.updateRecipient(recpx)
 	if err != nil {
 		t.Fatal(err)

--- a/platforms/solar/solar_test.go
+++ b/platforms/solar/solar_test.go
@@ -22,17 +22,17 @@ func TestDb(t *testing.T) {
 	}
 	oldDbDir := consts.DbDir
 	consts.DbDir = "blah" // set to a false db so that we can test errors arising from OpenDB()
-	x1, err := NewEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "originator")
+	x1, err := newEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "originator")
 	if err == nil {
 		t.Fatalf("Able to create entity with invalid db, quitting!")
 	}
 
-	_, err = x1.ProposeContract("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", 1, 1)
+	_, err = x1.Propose("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", 1, 1)
 	// 1 for retrieving martin as the recipient and 1 is the project Index
 	if err == nil {
 		t.Fatalf("Able to propose contract with invalid db, quitting!")
 	}
-	_, err = x1.OriginContract("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1) // 1 is the index for martin
+	_, err = x1.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1) // 1 is the index for martin
 	if err == nil {
 		t.Fatal("Able to originate contract with invalid db, quitting!")
 	}
@@ -40,7 +40,7 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Able to promote contract even with invalid db, quitting!")
 	}
-	var y1 SolarProject
+	var y1 Project
 	err = y1.Save()
 	if err == nil {
 		t.Fatalf("Able to save file even though no db is present, quitting!")
@@ -53,24 +53,24 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Able to retrieve projects with invalid db, quitting!")
 	}
-	_, err = RetrieveProjects(1)
+	_, err = RetrieveProjectsAtStage(1)
 	if err == nil {
 		t.Fatalf("Able to retrieve stage projects with invalid db, quitting!")
 	}
-	_, err = RetrieveProjectsC(1, 1)
+	_, err = RetrieveContractorProjects(1, 1)
 	if err == nil {
 		t.Fatalf("Able to retrieve contractor projects with invalid db, quitting!")
 	}
-	_, err = RetrieveProjectsO(1, 1)
+	_, err = RetrieveOriginatorProjects(1, 1)
 	if err == nil {
 		t.Fatalf("Able to retrieve originated projects with invalid db, quitting!")
 	}
-	_, err = RetrieveProjectsR(1, 1)
+	_, err = RetrieveRecipientProjects(1, 1)
 	if err == nil {
 		t.Fatalf("Able to retrieve recipient projects with invalid db, quitting!")
 	}
 	var xy1 database.Investor
-	err = VoteTowardsProposedProject(&xy1, 1, 1)
+	err = VoteTowardsProposedProject(xy1.U.Index, 1, 1)
 	if err == nil {
 		t.Fatalf("Can vote towards a non existent proposed project, quitting!")
 	}
@@ -79,7 +79,7 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Can save entity which doesn't exist?")
 	}
-	_, err = RetrieveAllContractEntities("guarantor")
+	_, err = RetrieveAllEntities("guarantor")
 	if err == nil {
 		t.Fatalf("Can retreive contract entities from invalid db, quitting!")
 	}
@@ -98,7 +98,7 @@ func TestDb(t *testing.T) {
 	}
 	db.Close() // close immmediately after check
 	var project1 SolarParams
-	var dummy SolarProject
+	var dummy Project
 	// investors entity testing over, test recipients below in the same way
 	// now we repeat the same tests for all other entities
 	// connections and the other for non RPC connections
@@ -136,13 +136,13 @@ func TestDb(t *testing.T) {
 	project1.Location = "India Basin, San Francisco"
 	project1.MoneyRaised = 0
 	project1.Metadata = "India Basin is an upcoming creative project based in San Francisco that seeks to invite innovators from all around to participate"
-	project1.INVAssetCode = ""
-	project1.DEBAssetCode = ""
-	project1.PBAssetCode = ""
+	project1.InvestorAssetCode = ""
+	project1.DebtAssetCode = ""
+	project1.PaybackAssetCode = ""
 	project1.DateInitiated = ""
 	project1.Years = 3
-	project1.ProjectRecipient = recp
 	dummy.Params = project1
+	dummy.ProjectRecipient = recp
 	dummy.Contractor = newCE
 	dummy.Originator = newCE2
 	dummy.Stage = 3
@@ -179,7 +179,7 @@ func TestDb(t *testing.T) {
 	if projects[0].Params.Index != 1 {
 		t.Fatalf("Index of first element doesn't match, quitting!")
 	}
-	oProjects, err := RetrieveProjects(OriginProject)
+	oProjects, err := RetrieveProjectsAtStage(OriginProject)
 	if err != nil {
 		log.Println("Retrieve all error: ", err)
 		t.Errorf("Failed in retrieving all originated projects")
@@ -218,15 +218,15 @@ func TestDb(t *testing.T) {
 		t.Fatal(err)
 	}
 	// tests for originators
-	newCE, err = NewEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "originator")
+	newCE, err = newEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "originator")
 	if err != nil {
 		t.Fatal(err)
 	}
-	allOrigs, err := RetrieveAllContractEntities("originator")
+	allOrigs, err := RetrieveAllEntities("originator")
 	if err != nil {
 		t.Fatal(err)
 	}
-	acz1, err := RetrieveAllContractEntities("random")
+	acz1, err := RetrieveAllEntities("random")
 	if len(acz1) != 0 {
 		log.Println(acz1)
 		t.Fatalf("Category which does not exist exists?")
@@ -234,23 +234,23 @@ func TestDb(t *testing.T) {
 	if len(allOrigs) != 2 || allOrigs[0].U.Name != "NameOrigTest2" {
 		t.Fatal("Names don't match, quitting!")
 	}
-	_, err = RetrieveAllContractEntities("guarantor")
+	_, err = RetrieveAllEntities("guarantor")
 	if err != nil {
 		t.Fatal(err)
 	}
-	allConts, err := RetrieveAllContractEntities("contractor")
+	allConts, err := RetrieveAllEntities("contractor")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(allConts) != 1 || allConts[0].U.Name != "NameConTest" {
 		t.Fatal("Names don't match, quitting!")
 	}
-	_, err = newCE.ProposeContract("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", recp.U.Index, 1)
+	_, err = newCE.Propose("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", recp.U.Index, 1)
 	// 1 for retrieving martin as the recipient and 1 is the project Index
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newCE.ProposeContract("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", 1000, 1)
+	_, err = newCE.Propose("100 16x32 panels", 28000, "Puerto Rico", 6, "LEED+ Gold rated panels and this is random data out of nowhere and we supply our own devs and provide insurance guarantee as well. Dual audit maintenance upto 1 year. Returns capped as per defaults", 1000, 1)
 	// 1 for retrieving martin as the recipient and 1 is the project Index
 	if err == nil {
 		t.Fatal("Able to retrieve non existent recipient, quitting!")
@@ -259,20 +259,20 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rOx.Params.ProjectRecipient = recp
+	rOx.ProjectRecipient = recp
 	err = rOx.Save()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	allPCs, err := RetrieveProjectsR(ProposedProject, 6)
+	allPCs, err := RetrieveRecipientProjects(ProposedProject, 6)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(allPCs) != 1 { // add check for stuff here
 		log.Println("LEN all proposed projects", len(allPCs))
 	}
-	rPC, err := FindInKey(2, allPCs)
+	rPC, err := findInKey(2, allPCs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,17 +281,17 @@ func TestDb(t *testing.T) {
 	}
 
 	// now come the failure cases which should fail and we shall catch the case when they don't
-	allPCs, err = RetrieveProjectsC(ProposedProject, 2)
+	allPCs, err = RetrieveContractorProjects(ProposedProject, 2)
 	if len(allPCs) != 0 {
 		log.Println("LEBNGRG: ", len(allPCs))
 		t.Fatalf("Retrieving a missing contract succeeds, quitting!")
 	}
-	rPC, err = FindInKey(2, allPCs)
+	rPC, err = findInKey(2, allPCs)
 	if err == nil {
 		t.Fatalf("Entity which should be missing exists!")
 	}
 
-	// newCE, err = NewEntity("ConTest", "pwd", "NameConTest", "123 ABC Street", "ConDescription", "contractor")
+	// newCE, err = newEntity("ConTest", "pwd", "NameConTest", "123 ABC Street", "ConDescription", "contractor")
 	rCE, err := SearchForEntity("ConTest", "9f88a8d40b90616715f868ed195d24e5df994f56bce34eddb022c213484eb0f220d8907e4ecd8f64ddd364cb30bb5758b32ee26541f340b930f7e5bf756907a4")
 	if err != nil {
 		t.Fatal(err)
@@ -302,13 +302,13 @@ func TestDb(t *testing.T) {
 	}
 	trC1, err := RetrieveEntity(7)
 	if err != nil || trC1.U.Index == 0 {
-		t.Fatal("SolarProject Entity lookup failed")
+		t.Fatal("Project Entity lookup failed")
 	}
-	tmpx1, err := newCE2.OriginContract("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", recp.U.Index) // 1 is the index for martin
+	tmpx1, err := newCE2.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", recp.U.Index) // 1 is the index for martin
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = newCE2.OriginContract("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1000) // 1 is the index for martin
+	_, err = newCE2.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1000) // 1 is the index for martin
 	if err == nil {
 		t.Fatalf("Not quitting for invalid recipient index")
 	}
@@ -317,7 +317,7 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	allOOs, err := RetrieveProjects(6) // this checks for stage 1 and not zero like the thing installed above
+	allOOs, err := RetrieveProjectsAtStage(6) // this checks for stage 1 and not zero like the thing installed above
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -330,7 +330,12 @@ func TestDb(t *testing.T) {
 		t.Fatalf("Projects could not be retrieved!")
 	}
 	project1.Index = len(indexCheck) + 1
-	nOP, err := NewOriginProject(project1, newCE2)
+	nOP, err := newOriginProject(project1, newCE2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nOP.ProjectRecipient = recp
+	err = nOP.Save()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,7 +424,7 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	allO, err := RetrieveProjectsO(OriginProject, newCE2.U.Index)
+	allO, err := RetrieveOriginatorProjects(OriginProject, newCE2.U.Index)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,23 +439,18 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = VoteTowardsProposedProject(&inv, 100, 2)
+	err = VoteTowardsProposedProject(inv.U.Index, 100, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// func UpdateProjectSlice(a *database.Recipient, project SolarParams) error {
-	recp.ReceivedSolarProjects = append(recp.ReceivedSolarProjects, project1.DEBAssetCode)
+	recp.ReceivedSolarProjects = append(recp.ReceivedSolarProjects, project1.DebtAssetCode)
 	// the above thing is to test the function itself and not the functionality since
-	// DEBAssetCode for project1 should be empty
+	// DebtAssetCode for project1 should be empty
 	err = recp.Save()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = UpdateProjectSlice(&recp, project1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = nOP.RecipientAuthorizeContract(recp) // again a placeholder for testing this function, not the flow itself
+	err = RecipientAuthorize(nOP.Params.Index, recp) // again a placeholder for testing this function, not the flow itself
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +458,7 @@ func TestDb(t *testing.T) {
 	if chk != "0.257143" {
 		t.Fatalf("Balance doesn't match , quitting!")
 	}
-	var arr []SolarProject
+	var arr []Project
 	x, err := SelectContractByPrice(arr)
 	if err == nil {
 		t.Fatalf("Empty array returns choice")
@@ -477,12 +477,12 @@ func TestDb(t *testing.T) {
 		t.Fatal(err)
 	}
 	/*
-	sc1[0]: YEARS: 3, PRICE: 14000
-	sc1[1]: YEARS: 6, PRICE: 28000
-	sc1[2]: YEARS: 5, PRICE: 14000
-	sc1[3]: YEARS: 3, PRICE: 14000
+		sc1[0]: YEARS: 3, PRICE: 14000
+		sc1[1]: YEARS: 6, PRICE: 28000
+		sc1[2]: YEARS: 5, PRICE: 14000
+		sc1[3]: YEARS: 3, PRICE: 14000
 	*/
-	var arrx []SolarProject // (6, 28000), (3, 14000)
+	var arrx []Project // (6, 28000), (3, 14000)
 	arrx = append(arr, sc1[1])
 	arrx = append(arr, sc1[0])
 	_, err = SelectContractByTime(arrx)
@@ -503,23 +503,23 @@ func TestDb(t *testing.T) {
 	if y.Params.Index != nOP.Params.Index {
 		t.Fatalf("Indices don't match, quitting!")
 	}
-	_, err = NewEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "developer")
+	_, err = newEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "developer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = NewEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "guarantor")
+	_, err = newEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "guarantor")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = NewEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "invalid")
+	_, err = newEntity("OrigTest", "pwd", "blah", "NameOrigTest", "123 ABC Street", "OrigDescription", "invalid")
 	if err == nil {
 		t.Fatalf("Not able to catch invalid contractor error, quitting!")
 	}
-	_, err = RetrieveAllContractEntities("developer")
+	_, err = RetrieveAllEntities("developer")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = RetrieveAllContractEntities("gurantor")
+	_, err = RetrieveAllEntities("gurantor")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -527,14 +527,12 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Not able to catch invalid entity error, quitting!")
 	}
-	// func Payback(a *database.Recipient, uContract SolarProject, assetName string, issuerPubkey string, amount string, seed string) error
-	var ax1 database.Recipient
-	var uContract SolarProject
-	err = Payback(&ax1, uContract, "", "", "", "")
+	// func Payback(a *database.Recipient, project Project, assetName string, issuerPubkey string, amount string, seed string) error
+	err = Payback(1, 1, "", "", "", "", "")
 	if err == nil {
 		t.Fatal("Invalid params not caught, exiting!")
 	}
-	_, err = newEntityHelper("x", "x", "x", "x", "123 ABC Street", "x", "random")
+	_, err = newEntity("x", "x", "x", "x", "123 ABC Street", "x", "random")
 	if err == nil {
 		t.Fatalf("not able to catch invalid entity error")
 	}

--- a/platforms/solar/stages.go
+++ b/platforms/solar/stages.go
@@ -22,47 +22,47 @@ var (
 // project
 // we could also alternately define contract states and then read the state from
 // our side and then compress this into a single function
-func (a *SolarProject) SetPreOriginProject() error {
+func (a *Project) SetPreOriginProject() error {
 	a.Stage = 0
 	return a.Save()
 }
 
-func (a *SolarProject) SetLegalContractStage() error {
+func (a *Project) SetLegalContractStage() error {
 	a.Stage = 0.5
 	return a.Save()
 }
 
-func (a *SolarProject) SetOriginProject() error {
+func (a *Project) SetOriginProject() error {
 	a.Stage = 1
 	return a.Save()
 }
 
-func (a *SolarProject) SetOpenForMoneyStage() error {
+func (a *Project) SetOpenForMoneyStage() error {
 	a.Stage = 1.5
 	return a.Save()
 }
 
-func (a *SolarProject) SetProposedProject() error {
+func (a *Project) SetProposedProject() error {
 	a.Stage = 2
 	return a.Save()
 }
 
-func (a *SolarProject) SetFinalizedProject() error {
+func (a *Project) SetFinalizedProject() error {
 	a.Stage = 3
 	return a.Save()
 }
 
-func (a *SolarProject) SetFundedProject() error {
+func (a *Project) SetFundedProject() error {
 	a.Stage = 4
 	return a.Save()
 }
 
-func (a *SolarProject) SetInstalledProjectStage() error {
+func (a *Project) SetInstalledProjectStage() error {
 	a.Stage = 5
 	return a.Save()
 }
 
-func (a *SolarProject) SetPowerGenerationStage() error {
+func (a *Project) SetPowerGenerationStage() error {
 	a.Stage = 6
 	return a.Save()
 }
@@ -70,7 +70,7 @@ func (a *SolarProject) SetPowerGenerationStage() error {
 // MW: Consider the steps required for the promotion of the project to happen (eg. verification and validation)
 func PromoteStage0To1Project(index int) error {
 	// we need to upgrade the contract's whose index is contractIndex to stage 1
-	projects, err := RetrieveProjects(PreOriginProject)
+	projects, err := RetrieveProjectsAtStage(PreOriginProject)
 	if err != nil {
 		return err
 	}
@@ -81,5 +81,5 @@ func PromoteStage0To1Project(index int) error {
 			return elem.SetOriginProject() // upgrade stage of this project
 		}
 	}
-	return fmt.Errorf("SolarProject not found, erroring!")
+	return fmt.Errorf("Project not found, erroring!")
 }

--- a/prettyprint.go
+++ b/prettyprint.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stellar/go/protocols/horizon"
 )
 
-func PrintProjects(projects []solar.SolarProject) {
+func PrintProjects(projects []solar.Project) {
 	for _, project := range projects {
 		PrintProject(project)
 	}
 }
 
 // this function pretty prints out some stuff that we need in main.go
-func PrintProject(project solar.SolarProject) {
+func PrintProject(project solar.Project) {
 	fmt.Println("          PROJECT INDEX: ", project.Params.Index)
 	fmt.Println("          Panel Size: ", project.Params.PanelSize)
 	fmt.Println("          Total Value: ", project.Params.TotalValue)
@@ -27,22 +27,22 @@ func PrintProject(project solar.SolarProject) {
 	PrintEntity(project.Originator)
 	fmt.Println("          PROJECT STAGE: ", project.Stage)
 	fmt.Println("          RECIPIENT: ")
-	PrintRecipient(project.Params.ProjectRecipient)
+	PrintRecipient(project.ProjectRecipient)
 	if project.Stage >= 2 {
 		fmt.Println("          PROJECT CONTRACTOR: ")
 		PrintEntity(project.Contractor)
 		fmt.Println("          Votes: ", project.Params.Votes)
 	}
 	if project.Stage >= 3 {
-		fmt.Println("          Investor Asset Code: ", project.Params.INVAssetCode)
+		fmt.Println("          Investor Asset Code: ", project.Params.InvestorAssetCode)
 		fmt.Println("          INVESTORS: ")
-		for _, investor := range project.Params.ProjectInvestors {
+		for _, investor := range project.ProjectInvestors {
 			PrintInvestor(investor)
 		}
 	}
 	if project.Stage == 4 {
-		fmt.Println("          Debt Asset Code: ", project.Params.DEBAssetCode)
-		fmt.Println("          Payback Asset Code: ", project.Params.PBAssetCode)
+		fmt.Println("          Debt Asset Code: ", project.Params.DebtAssetCode)
+		fmt.Println("          Payback Asset Code: ", project.Params.PaybackAssetCode)
 		fmt.Println("          Balance Left: ", project.Params.BalLeft)
 		fmt.Println("          Date Initiated: ", project.Params.DateInitiated)
 		fmt.Println("          Date Last Paid: ", project.Params.DateLastPaid)
@@ -55,7 +55,7 @@ func PrintInvestor(investor database.Investor) {
 	fmt.Println("          Your Seed is: ", investor.U.EncryptedSeed)
 	fmt.Println("          Your Voting Balance is: ", investor.VotingBalance)
 	fmt.Println("          You have Invested: ", investor.AmountInvested)
-	fmt.Println("          Your Invested Assets are: ", investor.InvestedAssets)
+	fmt.Println("          Your Invested Assets are: ", investor.InvestedSolarProjects)
 	fmt.Println("          Your Username is: ", investor.U.LoginUserName)
 	fmt.Println("          Your Password hash is: ", investor.U.LoginPassword)
 }

--- a/rpc/projects.go
+++ b/rpc/projects.go
@@ -23,12 +23,12 @@ func setupProjectRPCs() {
 	getFundedProjects()
 }
 
-func parseProject(r *http.Request) (solar.SolarProject, error) {
-	// we need to create an instance of the SolarProject
+func parseProject(r *http.Request) (solar.Project, error) {
+	// we need to create an instance of the Project
 	// and then map values if they do exist
 	// note that we just prepare the project here and don't invest in it
 	// for that, we need new a new investor struct and a recipient struct
-	var prepProject solar.SolarProject
+	var prepProject solar.Project
 	err := r.ParseForm()
 	if err != nil {
 		return prepProject, err
@@ -62,7 +62,7 @@ func insertProject() {
 	// look into a way where we can define originators in the route as well
 	http.HandleFunc("/project/insert", func(w http.ResponseWriter, r *http.Request) {
 		checkPost(w, r)
-		var prepProject solar.SolarProject
+		var prepProject solar.Project
 		prepProject, err := parseProject(r)
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)
@@ -115,7 +115,7 @@ func getProject() {
 
 func projectHandler(w http.ResponseWriter, r *http.Request, stage float64) {
 	checkGet(w, r)
-	allProjects, err := solar.RetrieveProjects(stage)
+	allProjects, err := solar.RetrieveProjectsAtStage(stage)
 	if err != nil {
 		errorHandler(w, r, http.StatusNotFound)
 		return

--- a/rpc/users.go
+++ b/rpc/users.go
@@ -38,7 +38,7 @@ func ValidateUser() {
 		var prepRecipient database.Recipient
 		rec := false
 		prepInvestor, err = database.RetrieveInvestor(prepUser.Index)
-		if err != nil || prepInvestor.U.Index == 0 {
+		if err != nil {
 			// means the user is a recipient, retrieve recipient credentials
 			rec = true
 			prepRecipient, err = database.ValidateRecipient(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])

--- a/testdata.go
+++ b/testdata.go
@@ -14,9 +14,9 @@ func InsertDummyData() error {
 	var err error
 	// populate database with dumym data
 	var project1 solar.SolarParams
-	var contract1 solar.SolarProject
-	var contract2 solar.SolarProject
-	var contract3 solar.SolarProject
+	var contract1 solar.Project
+	var contract2 solar.Project
+	var contract3 solar.Project
 	var rec database.Recipient
 	allRecs, err := database.RetrieveAllRecipients()
 	if err != nil {
@@ -106,13 +106,13 @@ func InsertDummyData() error {
 	project1.Location = "India Basin, San Francisco"
 	project1.MoneyRaised = 0
 	project1.Metadata = "India Basin is an upcoming creative project based in San Francisco that seeks to invite innovators from all around to participate"
-	project1.INVAssetCode = ""
-	project1.DEBAssetCode = ""
-	project1.PBAssetCode = ""
+	project1.InvestorAssetCode = ""
+	project1.DebtAssetCode = ""
+	project1.PaybackAssetCode = ""
 	project1.DateInitiated = utils.Timestamp()
 	project1.Years = 3
-	project1.ProjectRecipient = rec
 	contract1.Params = project1
+	contract1.ProjectRecipient = rec
 	contract1.Contractor = c1
 	contract1.Originator = newOriginator
 	contract1.Stage = 3
@@ -127,12 +127,12 @@ func InsertDummyData() error {
 	project1.Location = "Kendall Square, Boston"
 	project1.MoneyRaised = 0
 	project1.Metadata = "Kendall Square is set in the heart of Cambridge and is a popular startup IT hub"
-	project1.INVAssetCode = ""
-	project1.DEBAssetCode = ""
-	project1.PBAssetCode = ""
+	project1.InvestorAssetCode = ""
+	project1.DebtAssetCode = ""
+	project1.PaybackAssetCode = ""
 	project1.DateInitiated = utils.Timestamp()
 	project1.Years = 5
-	project1.ProjectRecipient = rec
+	contract2.ProjectRecipient = rec
 	contract2.Params = project1
 	contract2.Contractor = c1
 	contract2.Originator = newOriginator
@@ -148,12 +148,12 @@ func InsertDummyData() error {
 	project1.Location = "Trafalgar Square, London"
 	project1.MoneyRaised = 0
 	project1.Metadata = "Trafalgar Square is set in the heart of London's financial district, with big banks all over"
-	project1.INVAssetCode = ""
-	project1.DEBAssetCode = ""
-	project1.PBAssetCode = ""
+	project1.InvestorAssetCode = ""
+	project1.DebtAssetCode = ""
+	project1.PaybackAssetCode = ""
 	project1.DateInitiated = utils.Timestamp()
 	project1.Years = 7
-	project1.ProjectRecipient = rec
+	contract3.ProjectRecipient = rec
 	contract3.Params = project1
 	contract3.Contractor = c1
 	contract3.Originator = newOriginator
@@ -163,7 +163,7 @@ func InsertDummyData() error {
 		return fmt.Errorf("Error inserting project into db")
 	}
 
-	pc, err := newOriginator.OriginContract("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1) // 1 is the idnex for martin
+	pc, err := newOriginator.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1) // 1 is the idnex for martin
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -187,11 +187,11 @@ func InsertDummyData() error {
 		log.Fatal(err)
 	}
 
-	_, err = solar.RetrieveAllContractEntities("originator")
+	_, err = solar.RetrieveAllEntities("originator")
 	if err != nil {
 		log.Fatal(err)
 	}
-	_, err = solar.RetrieveAllContractEntities("contractor")
+	_, err = solar.RetrieveAllEntities("contractor")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Changed function names as requested in review, moved around some functions depending on architecture, made some methods into functions since they need to be used by the rpc and avoided exporting functions that are not called outside the package.