### PR TITLE
Add RPCs and change project investment workflow

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -31,3 +31,6 @@ var PaybackInterval = time.Duration(1 * 60 * 60 * 24 * 30)                      
 var TestPaybackInterval = time.Duration(5)                                           // 5 seconds
 var DefaultRpcPort = 8080                                                            // the default port on which the rpc server of the platform starts
 var LoginRefreshInterval = time.Duration(5 * 60)                                     // every 5 minutes we refresh the teller to import the changes on the platform
+var PlatformPublicKey = ""                                                           // set this to empty and store during runtime
+var PlatformSeed = ""                                                                // set this to empty and store during runtime
+var LockInterval = int64(1 * 60 * 60 * 24 * 3)                                              // time a recipient is given to unlock the project and redeem investment

--- a/database/investor.go
+++ b/database/investor.go
@@ -211,7 +211,7 @@ func TopReputationInvestors() ([]Investor, error) {
 	}
 	for i, _ := range allInvestors {
 		for j, _ := range allInvestors {
-			if allInvestors[i].U.Reputation < allInvestors[j].U.Reputation {
+			if allInvestors[i].U.Reputation > allInvestors[j].U.Reputation {
 				tmp := allInvestors[i]
 				allInvestors[i] = allInvestors[j]
 				allInvestors[j] = tmp

--- a/database/recipient.go
+++ b/database/recipient.go
@@ -162,8 +162,7 @@ func TopReputationRecipient() ([]Recipient, error) {
 	}
 	for i, _ := range allRecipients {
 		for j, _ := range allRecipients {
-			fmt.Println("CHECK REPUT, i: ", allRecipients[i].U.Reputation, " j: ", allRecipients[j].U.Reputation)
-			if allRecipients[i].U.Reputation < allRecipients[j].U.Reputation {
+			if allRecipients[i].U.Reputation > allRecipients[j].U.Reputation {
 				tmp := allRecipients[i]
 				allRecipients[i] = allRecipients[j]
 				allRecipients[j] = tmp

--- a/database/user.go
+++ b/database/user.go
@@ -26,6 +26,7 @@ type User struct {
 	// PublicKey denotes the public key of the recipient
 	LoginUserName string
 	// the username you use to login to the platform
+	// TODO: change this to just "username"
 	LoginPassword string
 	// the password, which you use to authenticate on the platform
 	Address string
@@ -333,6 +334,7 @@ func AddInspector(userIndex int) error {
 	return user.Save()
 }
 
+// these two functions can be used as internal hnadlers and hte RPC can save reputation directly
 func (a *User) IncreaseReputation(reputation float64) error {
 	a.Reputation += reputation
 	return a.Save()
@@ -352,7 +354,7 @@ func TopReputationUsers() ([]User, error) {
 	}
 	for i, _ := range allUsers {
 		for j, _ := range allUsers {
-			if allUsers[i].Reputation < allUsers[j].Reputation {
+			if allUsers[i].Reputation > allUsers[j].Reputation {
 				tmp := allUsers[i]
 				allUsers[i] = allUsers[j]
 				allUsers[j] = tmp

--- a/database/user.go
+++ b/database/user.go
@@ -49,9 +49,10 @@ type User struct {
 	Notification bool
 	// GDPR, if user wants to opt in, set this to true. Default is false
 	Reputation float64
-	// Reputation contains the reputation of a good contractor. Reputation increases
+	// Reputation contains the reputation of a good user. Reputation increases
 	// for each completed bond and decreases for each bond cancelled. The frontend
-	// could have a table based on reputation scores
+	// could have a table based on reputation scores and use the appropriate scores for
+	// awarding badges or something to users with high reputation
 }
 
 // User is a metastrucutre that contains commonly used keys within a single umbrella

--- a/notif/notif.go
+++ b/notif/notif.go
@@ -12,6 +12,8 @@ import (
 // place with respect to a specific project / investment
 
 // MWTODO: Get comments on general text here
+// TODO: maybe encrypt the config file so a person with access to this file cannot
+// steal all credentials
 // footerString is a common footer string that is used by all emails
 var footerString = "Have a nice day!\n\nWarm Regards, \nThe OpenSolar Team\n\n\n\n" +
 	"You're receiving this email because your contact was given" +
@@ -30,7 +32,7 @@ func sendMail(body string, to string) error {
 		log.Println("Error while reading email values from config file")
 		return err
 	}
-	log.Println("VIPER CONFIG: ", viper.Get("email"), viper.Get("password"))
+	log.Println("SENDING EMAIL: ", viper.Get("email"), viper.Get("password"))
 	from := viper.Get("email").(string)    // interface to string
 	pass := viper.Get("password").(string) // interface to string
 	auth := smtp.PlainAuth("", from, pass, "smtp.gmail.com")
@@ -114,6 +116,19 @@ func SendPaybackNotifToInvestor(projIndex int, to string, stableUSDHash string, 
 		"The recipient's proofs of payment are attached below and may be used as future reference in case of discrepancies:  \n\n" +
 		"Stablecoin payment hash is: https://testnet.steexp.com/tx/" + stableUSDHash + "\n" +
 		"Debt asset hash is: https://testnet.steexp.com/tx/" + debtPaybackHash + "\n\n\n" +
+		footerString
+	return sendMail(body, to)
+}
+
+// SendPaybackNotifToInvestor sends a notification email to the investor when the recipient
+// pays back towards a particular order
+func SendUnlockNotifToRecipient(projIndex int, to string) error {
+	// this is sent to the investor on payback from an investor
+	body := "Greetings from the opensolar platform! \n\n" +
+		"We're writing to let you know that project number: " + utils.ItoS(projIndex) + " has been invested in\n\n" +
+		"You are required to logon to the platform within a period of 3(THREE) days in order to accept the investment\n\n" +
+		"If you choose to not accept the given investment in your project, please be warned that your reputation score " +
+		"will be adjusted accordingly and this may affect any future proposal that you seek funding for on the platform\n\n" +
 		footerString
 	return sendMail(body, to)
 }

--- a/platforms/solar/invest.go
+++ b/platforms/solar/invest.go
@@ -384,6 +384,6 @@ func sendRecipientAssets(projIndex int, issuerPubkey string, issuerSeed string) 
 	if recipient.U.Notification {
 		notif.SendInvestmentNotifToRecipient(project.Params.Index, recipient.U.Email, recpPbTrustHash, recpAssetHash, recpDebtTrustHash, recpDebtAssetHash)
 	}
-	fmt.Println("PROJECT %d's INVESTMENT CONFIRMED!", project.Params.Index)
+	fmt.Printf("PROJECT %d's INVESTMENT CONFIRMED!", project.Params.Index)
 	return project.Save()
 }

--- a/platforms/solar/solar_test.go
+++ b/platforms/solar/solar_test.go
@@ -133,24 +133,20 @@ func TestDb(t *testing.T) {
 	if err == nil {
 		t.Fatalf("PreInvestmentCheck succeeds, quitting!")
 	}
-	_, err = SendUSDToPlatform("", "", "", 1)
+	_, err = SendUSDToPlatform("", "", 1)
 	if err == nil {
 		t.Fatalf("SendUSDToPlatform succeeds, quitting!")
 	}
-	_, err = InvestInProject(1, 1, 1, "", "", "", "")
+	_, err = InvestInProject(1, 1, "", "")
 	if err == nil {
 		t.Fatalf("InvestInProject succeeds, quitting!")
 	}
-	_, err = SeedInvestInProject(1, 1, 1, "", "", "", "")
+	_, err = SeedInvestInProject(1, 1, 1, "", "", "")
 	if err == nil {
 		t.Fatalf("SeedInvestInProject succeeds, quitting!")
 	}
 	var tmpProj Project
 	var tmpRecp database.Recipient
-	err = tmpProj.sendRecipientAssets(tmpRecp, "", "", "")
-	if err == nil {
-		t.Fatalf("Sending recipient assets failed, quitting!")
-	}
 	tmpProj.SetInstalledProjectStage()
 	if err == nil {
 		t.Fatalf("Setting stage works with invalid db, quitting!")

--- a/rpc/investors.go
+++ b/rpc/investors.go
@@ -48,13 +48,11 @@ func insertInvestor() {
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
-		var rt StatusResponse
-		rt.Status = 200
-		MarshalSend(w, r, rt)
+		Send200(w, r)
 	})
 }
 
-// validateInvestor retreives the investor after valdiating if such an ivnestor exists
+// validateInvestor retrieves the investor after valdiating if such an ivnestor exists
 // by checking the pwhash of the given investor with the stored one
 func validateInvestor() {
 	http.HandleFunc("/investor/validate", func(w http.ResponseWriter, r *http.Request) {

--- a/rpc/investors.go
+++ b/rpc/investors.go
@@ -6,6 +6,10 @@ import (
 	"net/http"
 
 	database "github.com/OpenFinancing/openfinancing/database"
+	solar "github.com/OpenFinancing/openfinancing/platforms/solar"
+	utils "github.com/OpenFinancing/openfinancing/utils"
+	wallet "github.com/OpenFinancing/openfinancing/wallet"
+	xlm "github.com/OpenFinancing/openfinancing/xlm"
 )
 
 // setupInvestorRPCs sets up all RPCs related to the investor
@@ -13,17 +17,18 @@ func setupInvestorRPCs() {
 	insertInvestor()
 	validateInvestor()
 	getAllInvestors()
+	investInProject()
 }
 
 func parseInvestor(r *http.Request) (database.Investor, error) {
 	var prepInvestor database.Investor
 	err := r.ParseForm()
-	if err != nil || r.FormValue("LoginUserName") == "" || r.FormValue("LoginPassword") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
-		return prepInvestor, fmt.Errorf("One of required fields missing: LoginUserName, LoginPassword, Name, EPassword")
+	if err != nil || r.FormValue("username") == "" || r.FormValue("password") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
+		return prepInvestor, fmt.Errorf("One of required fields missing: username, password, Name, EPassword")
 	}
 
 	prepInvestor.AmountInvested = float64(0)
-	prepInvestor.U, err = database.NewUser(r.FormValue("LoginUserName"), r.FormValue("LoginPassword"), r.FormValue("Name"), r.FormValue("EPassword"))
+	prepInvestor.U, err = database.NewUser(r.FormValue("username"), r.FormValue("password"), r.FormValue("Name"), r.FormValue("EPassword"))
 	return prepInvestor, err
 }
 
@@ -54,11 +59,12 @@ func insertInvestor() {
 func validateInvestor() {
 	http.HandleFunc("/investor/validate", func(w http.ResponseWriter, r *http.Request) {
 		checkGet(w, r)
-		if r.URL.Query() == nil || r.URL.Query()["LoginUserName"] == nil || r.URL.Query()["LoginPassword"] == nil || len(r.URL.Query()["LoginPassword"][0]) != 128 { // sha 512 length
+		if r.URL.Query() == nil || r.URL.Query()["username"] == nil || r.URL.Query()["password"] == nil ||
+			len(r.URL.Query()["password"][0]) != 128 { // sha 512 length
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
-		prepInvestor, err := database.ValidateInvestor(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])
+		prepInvestor, err := database.ValidateInvestor(r.URL.Query()["username"][0], r.URL.Query()["password"][0])
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)
 			return
@@ -79,5 +85,61 @@ func getAllInvestors() {
 			return
 		}
 		MarshalSend(w, r, investors)
+	})
+}
+
+func investInProject() {
+	http.HandleFunc("/investor/invest", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		// need the following params to invest in a project:
+		// 1. Seed Password (for the investor)
+		// 2. project index
+		// 3. investment amount
+		// 4. Login username (for the investor)
+		// 5. Login Password (for the investor)
+		if r.URL.Query() == nil || r.URL.Query()["seedpwd"] == nil || r.URL.Query()["projIndex"] == nil ||
+			r.URL.Query()["amount"] == nil || r.URL.Query()["username"] == nil || r.URL.Query()["password"] == nil ||
+			len(r.URL.Query()["password"][0]) != 128 { // sha 512 length
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		investor, err := database.ValidateInvestor(r.URL.Query()["username"][0], r.URL.Query()["password"][0])
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		seedpwd := r.URL.Query()["seedpwd"][0]
+		investorSeed, err := wallet.DecryptSeed(investor.U.EncryptedSeed, seedpwd)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		projIndex := utils.StoI(r.URL.Query()["projIndex"][0])
+		amount := r.URL.Query()["amount"][0]
+		investorPubkey, err := wallet.ReturnPubkey(investorSeed)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		// splitting the conditions into two since in the future we will be returning
+		// error codes towards each type
+		if !xlm.AccountExists(investorPubkey) {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		// note that while using this route, we can't send the recipient assets (maybe)
+		// make it so in the UI that only they can accept an investment so we can get their
+		// seed and send them assets. By not accepting, they would forfeit their investment,
+		// so incentive would be there to unlock the seed.
+		_, err = solar.InvestInProject(projIndex, investor.U.Index, amount, investorSeed)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		Send200(w, r)
 	})
 }

--- a/rpc/projects.go
+++ b/rpc/projects.go
@@ -73,9 +73,7 @@ func insertProject() {
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
-		var rt StatusResponse
-		rt.Status = 200
-		MarshalSend(w, r, rt)
+		Send200(w, r)
 	})
 }
 

--- a/rpc/public.go
+++ b/rpc/public.go
@@ -1,0 +1,136 @@
+package rpc
+
+import (
+	"net/http"
+
+	database "github.com/OpenFinancing/openfinancing/database"
+)
+
+type SnInvestor struct {
+	Name                  string
+	InvestedSolarProjects []string
+	AmountInvested        float64
+	InvestedBonds         []string
+	InvestedCoops         []string
+	PublicKey             string
+}
+
+type SnRecipient struct {
+	Name                  string
+	PublicKey             string
+	ReceivedSolarProjects []string
+}
+
+type SnUser struct {
+	Name       string
+	PublicKey  string
+	Reputation float64
+}
+
+func setupPublicRoutes() {
+	getAllInvestorsPublic()
+	getAllRecipientsPublic()
+	getTopReputationPublic()
+}
+
+// MWTODO: get feedback on what routes to make public
+// public contains all the RPC routes that we explicitly intend to make public. Other
+// routes such as the invest route are thigns we could make private as well, but that
+// doesn't change the security model since we ask for username+pwauth
+func sanitizeInvestor(investor database.Investor) SnInvestor {
+	// this is a public route, so we shouldn't ideally return all parameters that are present
+	// in the investor struct
+	var sanitize SnInvestor
+	sanitize.Name = investor.U.Name
+	sanitize.InvestedSolarProjects = investor.InvestedSolarProjects
+	sanitize.AmountInvested = investor.AmountInvested
+	sanitize.InvestedBonds = investor.InvestedBonds
+	sanitize.InvestedCoops = investor.InvestedCoops
+	sanitize.PublicKey = investor.U.PublicKey
+	return sanitize
+}
+
+func sanitizeRecipient(recipient database.Recipient) SnRecipient {
+	// this is a public route, so we shouldn't ideally return all parameters that are present
+	// in the investor struct
+	var sanitize SnRecipient
+	sanitize.Name = recipient.U.Name
+	sanitize.PublicKey = recipient.U.PublicKey
+	sanitize.ReceivedSolarProjects = recipient.ReceivedSolarProjects
+	return sanitize
+}
+
+func sanitizeAllInvestors(investors []database.Investor) []SnInvestor {
+	var arr []SnInvestor
+	for _, elem := range investors {
+		arr = append(arr, sanitizeInvestor(elem))
+	}
+	return arr
+}
+
+func sanitizeUser(user database.User) SnUser {
+	var sanitize SnUser
+	sanitize.Name = user.Name
+	sanitize.PublicKey = user.PublicKey
+	sanitize.Reputation = user.Reputation
+	return sanitize
+}
+
+func sanitizeAllRecipients(recipients []database.Recipient) []SnRecipient {
+	var arr []SnRecipient
+	for _, elem := range recipients {
+		arr = append(arr, sanitizeRecipient(elem))
+	}
+	return arr
+}
+
+func sanitizeAllUsers(users []database.User) []SnUser {
+	var arr []SnUser
+	for _, elem := range users {
+		arr = append(arr, sanitizeUser(elem))
+	}
+	return arr
+}
+
+// getAllInvestors gets a list of all the investors in the system so that we can
+// display it to some entity that is interested to view such stats
+func getAllInvestorsPublic() {
+	http.HandleFunc("/public/investor/all", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		investors, err := database.RetrieveAllInvestors()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		sInvestors := sanitizeAllInvestors(investors)
+		MarshalSend(w, r, sInvestors)
+	})
+}
+
+// getAllInvestors gets a list of all the investors in the system so that we can
+// display it to some entity that is interested to view such stats
+func getAllRecipientsPublic() {
+	http.HandleFunc("/public/recipient/all", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		recipients, err := database.RetrieveAllRecipients()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		sRecipients := sanitizeAllRecipients(recipients)
+		MarshalSend(w, r, sRecipients)
+	})
+}
+
+func getTopReputationPublic() {
+	http.HandleFunc("/public/reputation/top", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		allUsers, err := database.TopReputationUsers()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		sUsers := sanitizeAllUsers(allUsers)
+		MarshalSend(w, r, sUsers)
+	})
+}

--- a/rpc/public.go
+++ b/rpc/public.go
@@ -13,12 +13,14 @@ type SnInvestor struct {
 	InvestedBonds         []string
 	InvestedCoops         []string
 	PublicKey             string
+	Reputation            float64
 }
 
 type SnRecipient struct {
 	Name                  string
 	PublicKey             string
 	ReceivedSolarProjects []string
+	Reputation            float64
 }
 
 type SnUser struct {
@@ -31,6 +33,7 @@ func setupPublicRoutes() {
 	getAllInvestorsPublic()
 	getAllRecipientsPublic()
 	getTopReputationPublic()
+	getInvTopReputationPublic()
 }
 
 // MWTODO: get feedback on what routes to make public
@@ -47,6 +50,7 @@ func sanitizeInvestor(investor database.Investor) SnInvestor {
 	sanitize.InvestedBonds = investor.InvestedBonds
 	sanitize.InvestedCoops = investor.InvestedCoops
 	sanitize.PublicKey = investor.U.PublicKey
+	sanitize.Reputation = investor.U.Reputation
 	return sanitize
 }
 
@@ -56,6 +60,7 @@ func sanitizeRecipient(recipient database.Recipient) SnRecipient {
 	var sanitize SnRecipient
 	sanitize.Name = recipient.U.Name
 	sanitize.PublicKey = recipient.U.PublicKey
+	sanitize.Reputation = recipient.U.Reputation
 	sanitize.ReceivedSolarProjects = recipient.ReceivedSolarProjects
 	return sanitize
 }
@@ -122,6 +127,8 @@ func getAllRecipientsPublic() {
 	})
 }
 
+// this is to publish a list of the users with the best feedback in the system in order
+// to award them abdges or something similar
 func getTopReputationPublic() {
 	http.HandleFunc("/public/reputation/top", func(w http.ResponseWriter, r *http.Request) {
 		checkGet(w, r)
@@ -132,5 +139,31 @@ func getTopReputationPublic() {
 		}
 		sUsers := sanitizeAllUsers(allUsers)
 		MarshalSend(w, r, sUsers)
+	})
+}
+
+func getRecpTopReputationPublic() {
+	http.HandleFunc("/public/recipient/reputation/top", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		allRecps, err := database.TopReputationRecipient()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		sRecipients := sanitizeAllRecipients(allRecps)
+		MarshalSend(w, r, sRecipients)
+	})
+}
+
+func getInvTopReputationPublic() {
+	http.HandleFunc("/public/investor/reputation/top", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		allInvs, err := database.TopReputationInvestors()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		sInvestors := sanitizeAllInvestors(allInvs)
+		MarshalSend(w, r, sInvestors)
 	})
 }

--- a/rpc/recipient.go
+++ b/rpc/recipient.go
@@ -68,9 +68,7 @@ func insertRecipient() {
 			return
 		}
 
-		var rt StatusResponse
-		rt.Status = 200
-		MarshalSend(w, r, rt)
+		Send200(w, r)
 	})
 }
 

--- a/rpc/recipient.go
+++ b/rpc/recipient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	database "github.com/OpenFinancing/openfinancing/database"
 	solar "github.com/OpenFinancing/openfinancing/platforms/solar"
@@ -22,17 +23,19 @@ func setupRecipientRPCs() {
 	storeDeviceId()
 	storeStartTime()
 	storeDeviceLocation()
+	changeReputationRecp()
+	chooseBlindAuction()
 }
 
 func parseRecipient(r *http.Request) (database.Recipient, error) {
 	var prepRecipient database.Recipient
 	err := r.ParseForm()
-	if err != nil || r.FormValue("LoginUserName") == "" || r.FormValue("LoginPassword") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
+	if err != nil || r.FormValue("username") == "" || r.FormValue("pwhash") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
 		// don't care which type of error because you send 404 anyway
-		return prepRecipient, fmt.Errorf("One of required fields missing: LoginUserName, LoginPassword, Name, EPassword")
+		return prepRecipient, fmt.Errorf("One of required fields missing: username, pwhash, Name, EPassword")
 	}
 
-	prepRecipient.U, err = database.NewUser(r.FormValue("LoginUserName"), r.FormValue("LoginPassword"), r.FormValue("Name"), r.FormValue("EPassword"))
+	prepRecipient.U, err = database.NewUser(r.FormValue("username"), r.FormValue("pwhash"), r.FormValue("Name"), r.FormValue("EPassword"))
 	log.Println("Parsed recipient: ", prepRecipient)
 	return prepRecipient, err
 }
@@ -76,13 +79,13 @@ func validateRecipient() {
 	http.HandleFunc("/recipient/validate", func(w http.ResponseWriter, r *http.Request) {
 		checkGet(w, r)
 		// need to pass the pwhash param here
-		if r.URL.Query() == nil || r.URL.Query()["LoginUserName"] == nil ||
-			len(r.URL.Query()["LoginPassword"][0]) != 128 {
+		if r.URL.Query() == nil || r.URL.Query()["username"] == nil ||
+			len(r.URL.Query()["pwhash"][0]) != 128 {
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
 
-		prepRecipient, err := database.ValidateRecipient(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])
+		prepRecipient, err := database.ValidateRecipient(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)
 			return
@@ -127,12 +130,12 @@ func RecpValidateHelper(w http.ResponseWriter, r *http.Request) (database.Recipi
 	checkGet(w, r)
 	var prepRecipient database.Recipient
 	// need to pass the pwhash param here
-	if r.URL.Query() == nil || r.URL.Query()["LoginUserName"] == nil ||
-		len(r.URL.Query()["LoginPassword"][0]) != 128 {
+	if r.URL.Query() == nil || r.URL.Query()["username"] == nil ||
+		len(r.URL.Query()["pwhash"][0]) != 128 {
 		return prepRecipient, fmt.Errorf("Invalid params passed")
 	}
 
-	prepRecipient, err := database.ValidateRecipient(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])
+	prepRecipient, err := database.ValidateRecipient(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])
 	if err != nil {
 		return prepRecipient, err
 	}
@@ -194,6 +197,122 @@ func storeDeviceLocation() {
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
+		Send200(w, r)
+	})
+}
+
+// changeReputation changes the reputation of a specified recipient
+func changeReputationRecp() {
+	http.HandleFunc("/recipient/reputation", func(w http.ResponseWriter, r *http.Request) {
+		recipient, err := RecpValidateHelper(w, r)
+		if err != nil || r.URL.Query()["reputation"] == nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		reputation, err := strconv.ParseFloat(r.URL.Query()["reputation"][0], 32) // same as StoI but we need to catch the error here
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		err = database.ChangeRecpReputation(recipient.U.Index, reputation)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		Send200(w, r)
+	})
+}
+
+func chooseBlindAuction() {
+	http.HandleFunc("/recipient/auction/choose/blind", func(w http.ResponseWriter, r *http.Request) {
+		recipient, err := RecpValidateHelper(w, r)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		allContracts, err := solar.RetrieveRecipientProjects(solar.ProposedProject, recipient.U.Index)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		bestContract, err := solar.SelectContractBlind(allContracts)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		err = bestContract.SetFinalizedProject()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		Send200(w, r)
+	})
+}
+
+func chooseVickreyAuction() {
+	http.HandleFunc("/recipient/auction/choose/vickrey", func(w http.ResponseWriter, r *http.Request) {
+		recipient, err := RecpValidateHelper(w, r)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		allContracts, err := solar.RetrieveRecipientProjects(solar.ProposedProject, recipient.U.Index)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		// the only differing part in the three auction routes. Would be nice if there were
+		// some way to avoid repetition like this
+		bestContract, err := solar.SelectContractVickrey(allContracts)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		err = bestContract.SetFinalizedProject()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		Send200(w, r)
+	})
+}
+
+func chooseTimeAuction() {
+	http.HandleFunc("/recipient/auction/choose/time", func(w http.ResponseWriter, r *http.Request) {
+		recipient, err := RecpValidateHelper(w, r)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		allContracts, err := solar.RetrieveRecipientProjects(solar.ProposedProject, recipient.U.Index)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		// the only differing part in the three auction routes. Would be nice if there were
+		// some way to avoid repetition like this
+		bestContract, err := solar.SelectContractTime(allContracts)
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
+		err = bestContract.SetFinalizedProject()
+		if err != nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+
 		Send200(w, r)
 	})
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 )
 
+// TODO: have some nice APi documentation page for this so that we can easily reference
 type PingResponse struct {
 	// pingresponse returns "alive" when called could be used by services
 	// that scan for uptime
@@ -114,17 +115,16 @@ func StartServer(port string) {
 	// to access the API
 	// a potential improvement will be to add something like macaroons
 	// so that we can serve over an authenticated channel
+	// setup all related handlers
 	setupBasicHandlers()
-	// setup basic handlers - / and /ping
 	setupProjectRPCs()
-	// setup project related RPCs
 	setupInvestorRPCs()
-	// setup investor related RPCs
 	setupRecipientRPCs()
-	// setup recipient related RPCs
 	setupBondRPCs()
 	setupCoopRPCs()
 	setupUserRpcs()
+	setupStableCoinRPCs()
+
 	portString := ":" + port // weird construction, but this should work
 	log.Fatal(http.ListenAndServe(portString, nil))
 }

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -13,17 +13,12 @@ import (
 )
 
 // TODO: have some nice APi documentation page for this so that we can easily reference
-type PingResponse struct {
-	// pingresponse returns "alive" when called could be used by services
-	// that scan for uptime
-	Status string
-}
 
 type StatusResponse struct {
 	Status int
 }
 
-// setupBasicHandlers sets up two hadnler functions that can be used to serve a default
+// setupBasicHandlers sets up two handler functions that can be used to serve a default
 // 404 response when we either error out or received input is incorrect.  This is not
 // exactly ideal, because we don't expcet the RPC to be exposed and would like some more
 // errors when we handle it on the frontend, but this makes for more a bit more
@@ -37,6 +32,7 @@ func WriteToHandler(w http.ResponseWriter, jsonString []byte) {
 	w.Header().Add("Access-Control-Allow-Headers", "Accept, Authorization, Cache-Control, Content-Type")
 	w.Header().Add("Access-Control-Allow-Methods", "*")
 	w.Header().Add("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
 	w.Write(jsonString)
 }
 
@@ -50,12 +46,14 @@ func MarshalSend(w http.ResponseWriter, r *http.Request, x interface{}) {
 }
 
 func Send200(w http.ResponseWriter, r *http.Request) {
+	// TODO: have differnet functions that will send the appropriate repsonse codes
 	var rt StatusResponse
 	rt.Status = 200
 	MarshalSend(w, r, rt)
 }
 
 func checkOrigin(w http.ResponseWriter, r *http.Request) {
+	// re-enable this function for all private routes
 	// if r.Header.Get("Origin") != "localhost" { // allow only our frontend UI to connect to our RPC instance
 	// 	http.Error(w, "404 page not found", http.StatusNotFound)
 	// }
@@ -94,9 +92,7 @@ func setupDefaultHandler() {
 func setupPingHandler() {
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		checkGet(w, r)
-		var pr PingResponse
-		pr.Status = "Alive"
-		MarshalSend(w, r, pr)
+		Send200(w, r)
 	})
 }
 
@@ -124,6 +120,7 @@ func StartServer(port string) {
 	setupCoopRPCs()
 	setupUserRpcs()
 	setupStableCoinRPCs()
+	setupPublicRoutes()
 
 	portString := ":" + port // weird construction, but this should work
 	log.Fatal(http.ListenAndServe(portString, nil))

--- a/rpc/stablecoin.go
+++ b/rpc/stablecoin.go
@@ -1,0 +1,45 @@
+package rpc
+
+import (
+	"log"
+	"net/http"
+
+	stablecoin "github.com/OpenFinancing/openfinancing/stablecoin"
+	wallet "github.com/OpenFinancing/openfinancing/wallet"
+)
+
+// this file handles the RPCs necessary for converting a fixed amount of XLM into
+// stablecoins. Right now, this is hooked to our account which serves the stablecoin
+// but in the future, we can have any provider that is willing to provide this
+// We have get requests here simply because they're easy to handle.
+
+func setupStableCoinRPCs() {
+	getStableCoin()
+}
+
+func getStableCoin() {
+	http.HandleFunc("/stablecoin/get", func(w http.ResponseWriter, r *http.Request) {
+		checkGet(w, r)
+		log.Println("Calling route")
+		if r.URL.Query() == nil || r.URL.Query()["seed"] == nil || r.URL.Query()["amount"] == nil {
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		receiverSeed := r.URL.Query()["seed"][0]
+		amount := r.URL.Query()["amount"][0] // in string
+		receiverPubkey, err := wallet.ReturnPubkey(receiverSeed)
+		if err != nil {
+			log.Println("Error while retrieving pubkey")
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		log.Println("Pubkey: ", receiverPubkey)
+		err = stablecoin.Exchange(receiverPubkey, receiverSeed, amount)
+		if err != nil {
+			log.Println("error while exchanging" ,err)
+			errorHandler(w, r, http.StatusNotFound)
+			return
+		}
+		Send200(w, r)
+	})
+}

--- a/rpc/users.go
+++ b/rpc/users.go
@@ -18,17 +18,32 @@ type ValidateParams struct {
 	Entity interface{}
 }
 
+func removeSeedRecp(recipient database.Recipient) database.Recipient {
+	// any field that is private needs to be set to null here. A person using the API
+	// knows the username and password anyway, so the route must return all routes
+	// that are accessible by a single login (uname + pwhash)
+	var dummy []byte
+	recipient.U.EncryptedSeed = dummy
+	return recipient
+}
+
+func removeSeedInv(investor database.Investor) database.Investor {
+	var dummy []byte
+	investor.U.EncryptedSeed = dummy
+	return investor
+}
+
 func ValidateUser() {
 	http.HandleFunc("/user/validate", func(w http.ResponseWriter, r *http.Request) {
 		checkOrigin(w, r)
 		checkGet(w, r)
 		// need to pass the pwhash param here
-		if r.URL.Query() == nil || r.URL.Query()["LoginUserName"] == nil || r.URL.Query()["LoginPassword"] == nil || len(r.URL.Query()["LoginPassword"][0]) != 128 {
+		if r.URL.Query() == nil || r.URL.Query()["username"] == nil || r.URL.Query()["pwhash"] == nil || len(r.URL.Query()["pwhash"][0]) != 128 {
 			errorHandler(w, r, http.StatusNotFound)
 			return
 		}
 
-		prepUser, err := database.ValidateUser(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])
+		prepUser, err := database.ValidateUser(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)
 			return
@@ -41,7 +56,7 @@ func ValidateUser() {
 		if err != nil {
 			// means the user is a recipient, retrieve recipient credentials
 			rec = true
-			prepRecipient, err = database.ValidateRecipient(r.URL.Query()["LoginUserName"][0], r.URL.Query()["LoginPassword"][0])
+			prepRecipient, err = database.ValidateRecipient(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])
 			if err != nil {
 				errorHandler(w, r, http.StatusNotFound)
 				return
@@ -52,11 +67,11 @@ func ValidateUser() {
 		var x ValidateParams
 		if rec {
 			x.Role = "Recipient"
-			x.Entity = prepRecipient
+			x.Entity = removeSeedRecp(prepRecipient)
 			MarshalSend(w, r, x)
 		} else {
 			x.Role = "Investor"
-			x.Entity = prepInvestor
+			x.Entity = removeSeedInv(prepInvestor)
 			MarshalSend(w, r, x)
 		}
 	})

--- a/stablecoin/exchange.go
+++ b/stablecoin/exchange.go
@@ -1,13 +1,22 @@
 package stablecoin
 
 import (
+	"fmt"
+	"log"
+
 	assets "github.com/OpenFinancing/openfinancing/assets"
 	consts "github.com/OpenFinancing/openfinancing/consts"
 	xlm "github.com/OpenFinancing/openfinancing/xlm"
-	"log"
 )
 
+// TODO: in case the person does not have enough stablecoin on hand to invest but has xlm,
+// we must offer to exchange their xlm for stablecoin and enable it by default.
 func Exchange(recipientPK string, recipientSeed string, convAmount string) error {
+
+	if !xlm.AccountExists(recipientPK) {
+		return fmt.Errorf("Account does not exist, quitting!")
+	}
+
 	hash, err := assets.TrustAsset(Code, consts.StableCoinAddress, consts.StablecoinTrustLimit, recipientPK, recipientSeed)
 	if err != nil {
 		return err

--- a/teller/rpc.go
+++ b/teller/rpc.go
@@ -47,14 +47,14 @@ func PingRpc() error {
 	if err != nil {
 		return err
 	}
-	var x rpc.PingResponse
+	var x rpc.StatusResponse
 	// now data is in byte, we need the other strucutre now
 	err = json.Unmarshal(data, &x)
 	if err != nil {
 		return err
 	}
 	// the result would be the status of the platform
-	ColorOutput("PLATFORM STATUS: "+x.Status, GreenColor)
+	ColorOutput("PLATFORM STATUS: "+utils.ItoS(x.Status), GreenColor)
 	return nil
 }
 

--- a/teller/server.go
+++ b/teller/server.go
@@ -44,8 +44,8 @@ func errorHandler(w http.ResponseWriter, r *http.Request, status int) {
 func PingHandler() {
 	http.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
 		checkGet(w, r)
-		var pr rpc.PingResponse
-		pr.Status = "Alive"
+		var pr rpc.StatusResponse
+		pr.Status = 200
 		prJson, err := json.Marshal(pr)
 		if err != nil {
 			errorHandler(w, r, http.StatusNotFound)

--- a/teller/xbreceiver.go
+++ b/teller/xbreceiver.go
@@ -8,7 +8,7 @@ import (
 )
 
 // this implements the xbee receiving stuff from the iot devices
-// TODO: do other stuff here, can;t really know what without testing with a zigbee module
+// TODO: do other stuff here, can't really know what without testing with a zigbee module
 
 type Receiver struct {
 	Receiver gobee.XBeeReceiver

--- a/test.go
+++ b/test.go
@@ -167,6 +167,7 @@ func main() {
 					break
 				}
 			case 1:
+				// getFinalProjects RPC
 				Stage3ProjectsDisplayPrompt()
 				break
 			case 2:
@@ -180,7 +181,7 @@ func main() {
 				PrintRecipient(recipient)
 				break
 			case 3:
-				// payback() RPC
+				// payback RPC
 				log.Println(recipient.ReceivedSolarProjects)
 				fmt.Println("WHICH PROJECT DO YOU WANT TO PAY BACK TOWARDS? (ENTER PROJECT NUMBER)")
 				projectNumber, err := scan.ScanForInt()
@@ -221,6 +222,7 @@ func main() {
 				}
 				break
 			case 4:
+				// getStableCoin RPC
 				log.Println("Enter the amount you want to convert into STABLEUSD")
 				convAmount, err := scan.ScanForStringWithCheckF()
 				if err != nil {
@@ -298,7 +300,11 @@ func main() {
 				default:
 					break
 				}
-				bestContract.SetFinalizedProject()
+				err = bestContract.SetFinalizedProject()
+				if err != nil {
+					log.Println(err)
+					break
+				}
 				log.Println("BEST CONTRACT IS: ")
 				PrintProject(bestContract)
 				// now the contract is at stage 3

--- a/test.go
+++ b/test.go
@@ -22,6 +22,8 @@ import (
 
 // test.go drives the CLI interface. Will be removed once we have a functioning frontend
 // that supplements the backend in an effective way.
+// TODO: move to the teller based config system mimicking the frontend once we have RPCs
+// for functions that will be used by the frontend.
 var opts struct {
 	Port int `short:"p" description:"The port on which the server runs on"`
 }
@@ -46,15 +48,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	var investorSeed string
 	var recipientSeed string
 
-	platformPublicKey, platformSeed, err := StartPlatform()
+	consts.PlatformPublicKey, consts.PlatformSeed, err = StartPlatform()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("PLATFORM SEED IS: %s\n PLATFORM PUBLIC KEY IS: %s\n", platformSeed, platformPublicKey)
+	log.Printf("PLATFORM SEED IS: %s\n PLATFORM PUBLIC KEY IS: %s\n", consts.PlatformSeed, consts.PlatformPublicKey)
 	// TODO: how much do we pay the investor?
 	// Do we sell the REC created from the solar panels only to the investor? If so,
 	// isn't that enough to propel investment in the solar contract itself?
@@ -112,6 +115,7 @@ func main() {
 		for {
 			fmt.Println("------------RECIPIENT INTERFACE------------")
 			fmt.Println("----CHOOSE ONE OF THE FOLLOWING OPTIONS----")
+			fmt.Println("  0. Display all Locked Projects")
 			fmt.Println("  1. Display all Open Projects (STAGE 3)")
 			fmt.Println("  2. Display my Profile")
 			fmt.Println("  3. Payback towards an Project (STAGE 6)")
@@ -129,10 +133,44 @@ func main() {
 				break
 			}
 			switch optI {
+			case 0:
+				fmt.Println("CHOOSE A PROJECT TO UNLOCK")
+				allProjects, err := solar.RetrieveLockedProjects()
+				if err != nil {
+					log.Println(err)
+					break
+				}
+				log.Println(allProjects)
+				pIndex, err := scan.ScanForInt()
+				if err != nil {
+					log.Println(err)
+					break
+				}
+
+				fmt.Println("ENTER SEED PASSWORD:")
+				// need to unlock the recipient account
+				seedpwd, err := scan.ScanRawPassword()
+				if err != nil {
+					log.Println(err)
+					break
+				}
+				// make sure that the seed provided is valid
+				_, err = wallet.DecryptSeed(recipient.U.EncryptedSeed, seedpwd)
+				if err != nil {
+					log.Println(err)
+					break
+				}
+				// unlock the project
+				err = solar.UnlockProject(recipient.U.LoginUserName, recipient.U.LoginPassword, pIndex, seedpwd)
+				if err != nil {
+					log.Println(err)
+					break
+				}
 			case 1:
 				Stage3ProjectsDisplayPrompt()
 				break
 			case 2:
+				// validateRecipient RPC
 				// retrieve again to get changes that may have occured in between
 				recipient, err = database.RetrieveRecipient(recipient.U.Index)
 				if err != nil {
@@ -142,6 +180,7 @@ func main() {
 				PrintRecipient(recipient)
 				break
 			case 3:
+				// payback() RPC
 				log.Println(recipient.ReceivedSolarProjects)
 				fmt.Println("WHICH PROJECT DO YOU WANT TO PAY BACK TOWARDS? (ENTER PROJECT NUMBER)")
 				projectNumber, err := scan.ScanForInt()
@@ -175,7 +214,7 @@ func main() {
 				}
 				fmt.Printf("PAYING BACK %s TOWARDS PROJECT NUMBER: %d\n", paybackAmount, rtContract.Params.Index) // use the rtContract.Params here instead of using projectNumber from long ago
 
-				err = solar.Payback(recipient.U.Index, rtContract.Params.Index, rtContract.Params.DebtAssetCode, paybackAmount, recipientSeed, platformPublicKey)
+				err = solar.Payback(recipient.U.Index, rtContract.Params.Index, rtContract.Params.DebtAssetCode, paybackAmount, recipientSeed, consts.PlatformPublicKey)
 				if err != nil {
 					log.Println("PAYBACK TX FAILED, PLEASE TRY AGAIN!", err)
 					break
@@ -451,6 +490,7 @@ func main() {
 				PrintInvestor(investor)
 				break
 			case 3:
+				// investInProject RPC
 				fmt.Println("----WHICH PROJECT DO YOU WANT TO INVEST IN? (ENTER ORDER NUMBER WITHOUT SPACES)----")
 				oNumber, err := scan.ScanForInt()
 				if err != nil {
@@ -489,27 +529,27 @@ func main() {
 					break
 				}
 
-				err = platform.RefillPlatform(platformPublicKey)
+				err = platform.RefillPlatform(consts.PlatformPublicKey)
 				if err != nil {
 					log.Println(err)
 					break
 				}
 
-				fmt.Printf("Platform seed is: %s and platform's publicKey is %s\n", platformSeed, platformPublicKey)
-				err = xlm.RefillAccount(investor.U.PublicKey, platformSeed)
+				fmt.Printf("Platform seed is: %s and platform's publicKey is %s\n", consts.PlatformSeed, consts.PlatformPublicKey)
+				err = xlm.RefillAccount(investor.U.PublicKey, consts.PlatformSeed)
 				if err != nil {
 					log.Println(err)
 					break
 				}
 				recipient := solarProject.ProjectRecipient
 				// from here on, reference recipient
-				err = xlm.RefillAccount(recipient.U.PublicKey, platformSeed)
+				err = xlm.RefillAccount(recipient.U.PublicKey, consts.PlatformSeed)
 				if err != nil {
 					log.Println(err)
 					break
 				}
 
-				platformBalance, err := xlm.GetNativeBalance(platformPublicKey)
+				platformBalance, err := xlm.GetNativeBalance(consts.PlatformPublicKey)
 				if err != nil {
 					log.Println(err)
 					break
@@ -536,7 +576,7 @@ func main() {
 				log.Println("The investor's public key and private key are: ", investor.U.PublicKey, " ", investorSeed)
 				log.Println("The recipient's public key and private key are: ", recipient.U.PublicKey, " ", recipientSeed)
 				// so now we have three entities setup, so we create the assets and invest in them
-				cProject, err := solar.InvestInProject(solarProject.Params.Index, investor.U.Index, recipient.U.Index, investmentAmount, investorSeed, recipientSeed, platformSeed)
+				cProject, err := solar.InvestInProject(solarProject.Params.Index, investor.U.Index, investmentAmount, investorSeed)
 				if err != nil {
 					log.Println(err)
 				} else {

--- a/test.go
+++ b/test.go
@@ -9,14 +9,14 @@ import (
 	consts "github.com/OpenFinancing/openfinancing/consts"
 	database "github.com/OpenFinancing/openfinancing/database"
 	ipfs "github.com/OpenFinancing/openfinancing/ipfs"
-	platform "github.com/OpenFinancing/openfinancing/platforms"
+	// platform "github.com/OpenFinancing/openfinancing/platforms"
 	solar "github.com/OpenFinancing/openfinancing/platforms/solar"
 	rpc "github.com/OpenFinancing/openfinancing/rpc"
 	scan "github.com/OpenFinancing/openfinancing/scan"
 	stablecoin "github.com/OpenFinancing/openfinancing/stablecoin"
 	utils "github.com/OpenFinancing/openfinancing/utils"
 	wallet "github.com/OpenFinancing/openfinancing/wallet"
-	xlm "github.com/OpenFinancing/openfinancing/xlm"
+	// xlm "github.com/OpenFinancing/openfinancing/xlm"
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -467,7 +467,7 @@ func main() {
 			fmt.Println("----CHOOSE ONE OF THE FOLLOWING OPTIONS----")
 			fmt.Println("  1. Display all Open Projects (STAGE 3)")
 			fmt.Println("  2. Display my Profile")
-			fmt.Println("  3. Invest in an Project (STAGE 3)")
+			// fmt.Println("  3. Invest in an Project (STAGE 3)")
 			fmt.Println("  4. Display All Balances")
 			fmt.Println("  5. Exchange XLM for USD")
 			fmt.Println("  6. Display all Origin (STAGE 1) Projects")
@@ -491,105 +491,17 @@ func main() {
 				break
 			case 3:
 				// investInProject RPC
-				fmt.Println("----WHICH PROJECT DO YOU WANT TO INVEST IN? (ENTER ORDER NUMBER WITHOUT SPACES)----")
-				oNumber, err := scan.ScanForInt()
-				if err != nil {
-					fmt.Println("Couldn't read user input")
-					break
-				}
-				// now the user has decided to invest in the asset with index uInput
-				// we need to retrieve the project and ask for confirmation
-				solarProject, err := solar.RetrieveProject(oNumber)
-				if err != nil {
-					log.Println("Couldn't retrieve project, try again!")
-					continue
-				}
-
-				if solarProject.Stage != 3 {
-					log.Println("Stage of Project doesn't match, try again!")
-				}
-
-				PrintProject(solarProject)
-				fmt.Println(" HOW MUCH DO YOU WANT TO INVEST?")
-				investmentAmount, err := scan.ScanForStringWithCheckI()
-				if err != nil {
-					log.Println(err)
-					break
-				}
-
-				fmt.Println(" DO YOU WANT TO CONFIRM THIS ORDER? (PRESS N IF YOU DON'T WANT TO)")
-				confirmOpt, err := scan.ScanForString()
-				if err != nil {
-					log.Println(err)
-					break
-				}
-
-				if confirmOpt == "N" || confirmOpt == "n" {
-					fmt.Println("YOU HAVE DECIDED TO CANCEL THIS ORDER")
-					break
-				}
-
-				err = platform.RefillPlatform(consts.PlatformPublicKey)
-				if err != nil {
-					log.Println(err)
-					break
-				}
-
-				fmt.Printf("Platform seed is: %s and platform's publicKey is %s\n", consts.PlatformSeed, consts.PlatformPublicKey)
-				err = xlm.RefillAccount(investor.U.PublicKey, consts.PlatformSeed)
-				if err != nil {
-					log.Println(err)
-					break
-				}
-				recipient := solarProject.ProjectRecipient
-				// from here on, reference recipient
-				err = xlm.RefillAccount(recipient.U.PublicKey, consts.PlatformSeed)
-				if err != nil {
-					log.Println(err)
-					break
-				}
-
-				platformBalance, err := xlm.GetNativeBalance(consts.PlatformPublicKey)
-				if err != nil {
-					log.Println(err)
-					break
-				}
-
-				// need the recipient's seed here as well, unlock the recipient account
-				fmt.Println("ENTER THE RECIPIENT'S SEED PASSWORD")
-				// ideally we should ask the recipient for confirmation in case he wants to
-				// receive the money or something. Also the fact that we can't unlock the account
-				// for him
-				seedpwd, err := scan.ScanRawPassword()
-				if err != nil {
-					log.Println(err)
-					break
-				}
-				seed, err := wallet.DecryptSeed(recipient.U.EncryptedSeed, seedpwd)
-				if err != nil {
-					log.Println(err)
-					break
-				}
-				recipientSeed = seed
-				log.Println(" Seed successfully unlocked")
-				log.Println("Platform's updated balance is: ", platformBalance)
-				log.Println("The investor's public key and private key are: ", investor.U.PublicKey, " ", investorSeed)
-				log.Println("The recipient's public key and private key are: ", recipient.U.PublicKey, " ", recipientSeed)
-				// so now we have three entities setup, so we create the assets and invest in them
-				cProject, err := solar.InvestInProject(solarProject.Params.Index, investor.U.Index, investmentAmount, investorSeed)
-				if err != nil {
-					log.Println(err)
-				} else {
-					fmt.Println("YOUR PROJECT INVESTMENT HAS BEEN CONFIRMED: ")
-					PrintProject(cProject)
-					fmt.Println("PLEASE CHECK A BLOCKCHAIN EXPLORER TO CONFIRM BALANCES: ")
-					fmt.Println("https://testnet.steexp.com/account/" + investor.U.PublicKey + "#balances")
-				}
-				break
+				// This route has been removed since once you invest in a particular order and it reaches
+				// the limit, this function will not transfer assets back to the recipient, resulting
+				// in an improper way of emulating the workflow. The only option is to call the route,
+				// which will be called by the frontend, so we can emulate this successfully.
+				// curl -X GET -H "Content-Type: application/x-www-form-urlencoded" -H "Origin: localhost" -H "Cache-Control: no-cache" "http://localhost:8080/investor/invest?username=john&password=9a768ace36ff3d1771d5c145a544de3d68343b2e76093cb7b2a8ea89ac7f1a20c852e6fc1d71275b43abffefac381c5b906f55c3bcff4225353d02f1d3498758&seedpwd=x&projIndex=1&amount=14000"
 			case 4:
 				BalanceDisplayPrompt(investor.U.PublicKey)
 				break
 			case 5:
+				// Stablecoin/get route
+				// curl -X GET -H "Content-Type: application/x-www-form-urlencoded" -H "Origin: localhost" -H "Cache-Control: no-cache" "http://localhost:8080/stablecoin/get?seed=SB2Z5GZASNF4ZR7263WWYISZP3UXSP7A6IP6ENZ44G4T44G6NVUCSVSP&amount=1"
 				log.Println("Enter the amount you want to convert into STABLEUSD")
 				convAmount, err := scan.ScanForStringWithCheckF()
 				if err != nil {


### PR DESCRIPTION
Earlier, we needed the recipient's seed to be able to invest in a project and that was made possible due to us using a CLI interface.