### PR TITLE
Change way errors are returned and printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenX
 
-[![Build Status](https://travis-ci.org/YaleOpenLab/openx.svg?branch=master)](https://travis-ci.org/YaleOpenLab/openx)
+[![Build Status](https://travis-ci.com/YaleOpenLab/openx.svg?branch=master)](https://travis-ci.com/YaleOpenLab/openx)
 [![Codecov](https://codecov.io/gh/YaleOpenLab/openx/branch/master/graph/badge.svg)](https://codecov.io/gh/YaleOpenLab/openx)
 
 This repo contains a WIP implementation of the OpenX platform of platforms idea in stellar. Broadly, the openx model seeks to implement the paradigm of investing without hassles and enabling smart ownership with the help of semi trusted entities on the blockchain. The openx model can be thought more generally as a platform of platforms and houses multiple platforms within it (in `platforms/`).  The goal is to have a common interface (where you complete KYC, authentication, etc) and to be able to invest in multiple assets. We use the help of the blockchain to have trustless proof of ownership and debt along with a publicly auditable source of data along with proofs. Currently there are two platforms housed within openx:

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 
 	consts "github.com/YaleOpenLab/openx/consts"
@@ -9,9 +9,8 @@ import (
 	solar "github.com/YaleOpenLab/openx/platforms/opensolar"
 	scan "github.com/YaleOpenLab/openx/scan"
 	"github.com/chzyer/readline"
-	"github.com/spf13/viper"
-
 	"github.com/fatih/color"
+	"github.com/spf13/viper"
 )
 
 // package emulator is used to emulate the environment of the platform and make changes
@@ -44,13 +43,12 @@ func SetupConfig() (string, error) {
 
 	err = viper.ReadInConfig()
 	if err != nil {
-		log.Println("Error while reading email values from config file")
-		return "", err
+		return "", errors.Wrap(err, "error while reading email values from config file")
 	}
 
 	PlatformPublicKey = viper.Get("PlatformPublicKey").(string)
 
-	fmt.Println("WELCOME TO THE SMARTSOLAR EMULATOR")
+	log.Println("WELCOME TO THE SMARTSOLAR EMULATOR")
 
 	ColorOutput("ENTER YOUR USERNAME: ", CyanColor)
 	username, err := scan.ScanForString()
@@ -67,7 +65,7 @@ func SetupConfig() (string, error) {
 	// need to validate with the RPC here
 	role, err := Login(username, pwhash)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not login to the platform")
 	}
 	return role, nil
 }

--- a/emulator/inputcont.go
+++ b/emulator/inputcont.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"strings"
 
@@ -16,8 +17,7 @@ func LoopCont(rl *readline.Instance) error {
 		// setup reader with max 4K input chars
 		msg, err := rl.Readline()
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not read user input")
 		}
 		msg = strings.TrimSpace(msg)
 		if len(msg) == 0 {
@@ -30,8 +30,7 @@ func LoopCont(rl *readline.Instance) error {
 
 		err = ParseInputCont(cmdslice)
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not parse input")
 		}
 	}
 	return nil
@@ -42,7 +41,7 @@ func ParseInputCont(input []string) error {
 	// Various command supported for the recipient
 	if len(input) == 0 {
 		// shouldn't happen, still
-		return fmt.Errorf("Length of input array is zero, quitting!")
+		return errors.New("Length of input array is zero, quitting!")
 	}
 	// input is greater than length 1 which means we can parse according to the command given
 	command := input[0]

--- a/emulator/inputinv.go
+++ b/emulator/inputinv.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"strings"
 
@@ -27,8 +28,7 @@ func LoopInv(rl *readline.Instance) error {
 		// setup reader with max 4K input chars
 		msg, err := rl.Readline()
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not read user input")
 		}
 		msg = strings.TrimSpace(msg)
 		if len(msg) == 0 {
@@ -41,8 +41,7 @@ func LoopInv(rl *readline.Instance) error {
 
 		err = ParseInputInv(cmdslice)
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not parse user input")
 		}
 	}
 	return nil
@@ -52,7 +51,7 @@ func ParseInputInv(input []string) error {
 	var err error
 	if len(input) == 0 {
 		// shouldn't happen, still
-		return fmt.Errorf("Length of input array is zero, quitting!")
+		return errors.New("Length of input array is zero, quitting!")
 	}
 	// input is greater than length 1 which means we can parse according to the command given
 	command := input[0]

--- a/emulator/inputorig.go
+++ b/emulator/inputorig.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"strings"
 
@@ -16,8 +17,7 @@ func LoopOrig(rl *readline.Instance) error {
 		// setup reader with max 4K input chars
 		msg, err := rl.Readline()
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not read user input")
 		}
 		msg = strings.TrimSpace(msg)
 		if len(msg) == 0 {
@@ -30,8 +30,7 @@ func LoopOrig(rl *readline.Instance) error {
 
 		err = ParseInputOrig(cmdslice)
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not parse user input")
 		}
 	}
 	return nil
@@ -42,7 +41,7 @@ func ParseInputOrig(input []string) error {
 	// Various command supported for the recipient
 	if len(input) == 0 {
 		// shouldn't happen, still
-		return fmt.Errorf("Length of input array is zero, quitting!")
+		return errors.New("Length of input array is zero, quitting!")
 	}
 	// input is greater than length 1 which means we can parse according to the command given
 	command := input[0]

--- a/emulator/inputrecp.go
+++ b/emulator/inputrecp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"strings"
 
@@ -16,8 +17,7 @@ func LoopRecp(rl *readline.Instance) error {
 		// setup reader with max 4K input chars
 		msg, err := rl.Readline()
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not read user input")
 		}
 		msg = strings.TrimSpace(msg)
 		if len(msg) == 0 {
@@ -30,8 +30,7 @@ func LoopRecp(rl *readline.Instance) error {
 
 		err = ParseInputRecp(cmdslice)
 		if err != nil {
-			log.Println(err)
-			return err
+			return errors.Wrap(err, "could not parse user input")
 		}
 	}
 	return nil
@@ -42,7 +41,7 @@ func ParseInputRecp(input []string) error {
 	// Various command supported for the recipient
 	if len(input) == 0 {
 		// shouldn't happen, still
-		return fmt.Errorf("Length of input array is zero, quitting!")
+		return errors.New("Length of input array is zero, quitting!")
 	}
 	// input is greater than length 1 which means we can parse according to the command given
 	command := input[0]

--- a/emulator/login.go
+++ b/emulator/login.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"github.com/pkg/errors"
 
 	database "github.com/YaleOpenLab/openx/database"
 	solar "github.com/YaleOpenLab/openx/platforms/opensolar"
@@ -16,97 +15,88 @@ func Login(username string, pwhash string) (string, error) {
 	var wString string
 	data, err := rpc.GetRequest(ApiUrl + "/user/validate?" + "username=" + username + "&pwhash=" + pwhash)
 	if err != nil {
-		return wString, err
+		return wString, errors.Wrap(err, "validate request failed")
 	}
 	var x rpc.ValidateParams
 	err = json.Unmarshal(data, &x)
 	if err != nil {
-		return wString, err
+		return wString, errors.Wrap(err, "could not unmarshal json")
 	}
 	switch x.Role {
 	case "Investor":
 		wString = "Investor"
 		data, err = rpc.GetRequest(ApiUrl + "/investor/validate?" + "username=" + username + "&pwhash=" + pwhash)
 		if err != nil {
-			return wString, err
+			return wString, errors.Wrap(err, "could not call ivnestor validate function")
 		}
 		var inv database.Investor
 		err = json.Unmarshal(data, &inv)
 		if err != nil {
-			return wString, err
+			return wString, errors.Wrap(err, "could not unmarshal json")
 		}
 		LocalInvestor = inv
 		ColorOutput("ENTER YOUR SEEDPWD: ", CyanColor)
 		LocalSeedPwd, err = scan.ScanRawPassword()
 		if err != nil {
-			log.Println(err)
-			return wString, err
+			return wString, errors.Wrap(err, "could not scan raw password")
 		}
 		LocalSeed, err = wallet.DecryptSeed(LocalInvestor.U.EncryptedSeed, LocalSeedPwd)
 		if err != nil {
-			log.Println(err)
-			return wString, err
+			return wString, errors.Wrap(err, "could not decrypt seed")
 		}
 	case "Recipient":
 		wString = "Recipient"
 		data, err = rpc.GetRequest(ApiUrl + "/recipient/validate?" + "username=" + username + "&pwhash=" + pwhash)
 		if err != nil {
-			return wString, err
+			return wString, errors.Wrap(err, "could not call recipient validate endpoint")
 		}
 		var recp database.Recipient
 		err = json.Unmarshal(data, &recp)
 		if err != nil {
-			return wString, err
+			return wString, errors.Wrap(err, "could not unmarshal json")
 		}
 		LocalRecipient = recp
 		ColorOutput("ENTER YOUR SEEDPWD: ", CyanColor)
 		LocalSeedPwd, err = scan.ScanRawPassword()
 		if err != nil {
-			log.Println(err)
-			return wString, err
+			return wString, errors.Wrap(err, "could not scan raw password")
 		}
 		LocalSeed, err = wallet.DecryptSeed(LocalRecipient.U.EncryptedSeed, LocalSeedPwd)
 		if err != nil {
-			log.Println(err)
-			return wString, err
+			return wString, errors.Wrap(err, "could not decrypt seed")
 		}
 	case "Entity":
 		data, err = rpc.GetRequest(ApiUrl + "/entity/validate?" + "username=" + username + "&pwhash=" + pwhash)
+		return wString, errors.Wrap(err, "could not call entity validate endpoint")
+	}
+	var entity solar.Entity
+	err = json.Unmarshal(data, &entity)
+	if err != nil {
+		return wString, errors.Wrap(err, "could not unmarshal json")
+	}
+	if entity.Contractor {
+		LocalContractor = entity
+		wString = "Contractor"
+	} else if entity.Originator {
+		LocalOriginator = entity
+		wString = "Originator"
+	} else {
+		return wString, errors.New("Not a contractor")
+	}
+	ColorOutput("ENTER YOUR SEEDPWD: ", CyanColor)
+	LocalSeedPwd, err = scan.ScanRawPassword()
+	if err != nil {
+		return wString, errors.Wrap(err, "could not scan raw password")
+	}
+	if entity.Contractor {
+		LocalSeed, err = wallet.DecryptSeed(LocalContractor.U.EncryptedSeed, LocalSeedPwd)
 		if err != nil {
-			return wString, err
+			return wString, errors.Wrap(err, "could not decrypt seed")
 		}
-		var entity solar.Entity
-		err = json.Unmarshal(data, &entity)
+	} else if entity.Originator {
+		LocalSeed, err = wallet.DecryptSeed(LocalOriginator.U.EncryptedSeed, LocalSeedPwd)
 		if err != nil {
-			return wString, err
-		}
-		if entity.Contractor {
-			LocalContractor = entity
-			wString = "Contractor"
-		} else if entity.Originator {
-			LocalOriginator = entity
-			wString = "Originator"
-		} else {
-			return wString, fmt.Errorf("Not a contractor")
-		}
-		ColorOutput("ENTER YOUR SEEDPWD: ", CyanColor)
-		LocalSeedPwd, err = scan.ScanRawPassword()
-		if err != nil {
-			log.Println(err)
-			return wString, err
-		}
-		if entity.Contractor {
-			LocalSeed, err = wallet.DecryptSeed(LocalContractor.U.EncryptedSeed, LocalSeedPwd)
-			if err != nil {
-				log.Println("error while decrpyting seed, quitting!", err)
-				return wString, err
-			}
-		} else if entity.Originator {
-			LocalSeed, err = wallet.DecryptSeed(LocalOriginator.U.EncryptedSeed, LocalSeedPwd)
-			if err != nil {
-				log.Println("error while decrpyting seed, quitting!", err)
-				return wString, err
-			}
+			return wString, errors.Wrap(err, "could not decrypt seed")
 		}
 	}
 

--- a/emulator/rpc.go
+++ b/emulator/rpc.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 
 	database "github.com/YaleOpenLab/openx/database"
@@ -75,7 +75,7 @@ func GetProjectIndex(assetName string) (int, error) {
 			return elem.Index, nil
 		}
 	}
-	return -1, fmt.Errorf("Not found")
+	return -1, errors.New("Not found")
 }
 
 func ProjectPayback(recpIndex string, assetName string,
@@ -83,7 +83,7 @@ func ProjectPayback(recpIndex string, assetName string,
 	// retrieve project index
 	projIndexI, err := GetProjectIndex(assetName)
 	if err != nil {
-		return fmt.Errorf("Couldn't pay")
+		return errors.New("Couldn't pay")
 	}
 	projIndex := utils.ItoS(projIndexI)
 	data, err := rpc.GetRequest(ApiUrl + "/recipient/payback?" + "recpIndex=" + recpIndex +
@@ -101,7 +101,7 @@ func ProjectPayback(recpIndex string, assetName string,
 		ColorOutput("PAID!", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out")
+	return errors.New("Errored out")
 }
 
 func RetrieveProject(stage float64) ([]solar.Project, error) {

--- a/models/helpers.go
+++ b/models/helpers.go
@@ -1,7 +1,7 @@
 package models
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"time"
 
@@ -21,8 +21,7 @@ func SendUSDToPlatform(invSeed string, invAmount string, memo string) (string, e
 
 	invPubkey, err := wallet.ReturnPubkey(invSeed)
 	if err != nil {
-		log.Println("Error while returning pubkey", err)
-		return "", err
+		return "", errors.Wrap(err, "error while returning pubkey")
 	}
 
 	var oldPlatformBalance string
@@ -34,8 +33,7 @@ func SendUSDToPlatform(invSeed string, invAmount string, memo string) (string, e
 
 	_, txhash, err := assets.SendAsset(consts.Code, consts.StablecoinPublicKey, consts.PlatformPublicKey, invAmount, invSeed, invPubkey, memo)
 	if err != nil {
-		log.Println("Sending stableusd to platform failed", consts.PlatformPublicKey, invAmount, invSeed, invPubkey, err)
-		return txhash, err
+		return txhash, errors.Wrap(err, "sending stableusd to platform failed")
 	}
 
 	log.Println("Sent STABLEUSD to platform, confirmation: ", txhash)
@@ -43,13 +41,11 @@ func SendUSDToPlatform(invSeed string, invAmount string, memo string) (string, e
 
 	newPlatformBalance, err := xlm.GetAssetBalance(consts.PlatformPublicKey, consts.Code)
 	if err != nil {
-		log.Println("Error while getting asset balance", err)
-		return txhash, err
+		return txhash, errors.Wrap(err, "error while getting asset balance")
 	}
 
 	if utils.StoF(newPlatformBalance)-utils.StoF(oldPlatformBalance) < utils.StoF(invAmount)-1 {
-		log.Println(newPlatformBalance, oldPlatformBalance)
-		return txhash, fmt.Errorf("Sent amount doesn't match with investment amount")
+		return txhash, errors.New("Sent amount doesn't match with investment amount")
 	}
 	return txhash, nil
 }

--- a/notif/notif.go
+++ b/notif/notif.go
@@ -1,6 +1,7 @@
 package notif
 
 import (
+	"github.com/pkg/errors"
 	"log"
 	"net/smtp"
 
@@ -28,8 +29,7 @@ func sendMail(body string, to string) error {
 	viper.AddConfigPath(".")
 	err = viper.ReadInConfig()
 	if err != nil {
-		log.Println("Error while reading email values from config file")
-		return err
+		return errors.Wrap(err, "error while reading email values from config file")
 	}
 	log.Println("SENDING EMAIL: ", viper.Get("email"), viper.Get("password"))
 	from := viper.Get("email").(string)    // interface to string
@@ -42,8 +42,7 @@ func sendMail(body string, to string) error {
 
 	err = smtp.SendMail("smtp.gmail.com:587", auth, from, []string{to}, []byte(msg))
 	if err != nil {
-		log.Printf("smtp error: %s", err)
-		return err
+		return errors.Wrap(err, "smtp error")
 	}
 	return nil
 }
@@ -284,8 +283,8 @@ func SendTellerPaymentFailedEmail(from string, projIndex string, deviceId string
 
 func SendTellerDownEmail(projIndex int, recpIndex int) error {
 	body := "Greetings from the opensolar platform! \n\n We're writing to let you know that remote teller " + utils.ItoS(projIndex) +
-	" installed on behalf of recipient with index: " + utils.ItoS(recpIndex) + " has not been responding to pings for a while. Please take action at " +
-	"the earliest," + "\n\n\n" +
-	footerString
+		" installed on behalf of recipient with index: " + utils.ItoS(recpIndex) + " has not been responding to pings for a while. Please take action at " +
+		"the earliest," + "\n\n\n" +
+		footerString
 	return sendMail(body, consts.PlatformEmail)
 }

--- a/ofcli/helpers.go
+++ b/ofcli/helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"github.com/pkg/errors"
 
 	database "github.com/YaleOpenLab/openx/database"
 	platform "github.com/YaleOpenLab/openx/platforms"
@@ -48,7 +49,7 @@ func NewUserPrompt() (string, string, string, string, error) {
 	err = database.CheckUsernameCollision(loginUserName)
 	if err != nil {
 		fmt.Printf("%s", "username already taken, please choose a different one")
-		return "", "", "", "", fmt.Errorf("username already taken, please choose a different one")
+		return "", "", "", "", errors.New("username already taken, please choose a different one")
 	}
 	fmt.Printf("%s: ", "ENTER DESIRED PASSWORD, YOU WILL NOT BE ASKED TO CONFIRM THIS")
 	loginPassword, err := scan.ScanForPassword()
@@ -117,7 +118,7 @@ func LoginPrompt() (database.Investor, database.Recipient, solar.Entity, bool, b
 		fmt.Println("WELCOME BACK CONTRACTOR")
 	} else {
 		log.Println("INVALID INPUT, EXITING!")
-		return investor, recipient, contractor, rbool, cbool, fmt.Errorf("INVALID INPUT, EXITING!")
+		return investor, recipient, contractor, rbool, cbool, errors.New("INVALID INPUT, EXITING!")
 	}
 	// ask for username and password combo here
 	fmt.Printf("%s: ", "ENTER YOUR USERNAME")
@@ -214,7 +215,7 @@ func ProposeContractPrompt(contractor *solar.Entity) error {
 	PrintProject(rContract)
 	if rContract.Index == 0 || rContract.Stage != 1 {
 		// prevent people form porposing contracts for non originated contracts
-		return fmt.Errorf("Invalid contract index")
+		return errors.New("Invalid contract index")
 	}
 	panelSize := rContract.PanelSize
 	location := rContract.Location

--- a/ofcli/testdata.go
+++ b/ofcli/testdata.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"log"
 
 	database "github.com/YaleOpenLab/openx/database"
@@ -145,7 +145,7 @@ func InsertDummyData() error {
 	project1.AuctionType = "blind"
 	err = project1.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	project2.Index = 2
@@ -167,7 +167,7 @@ func InsertDummyData() error {
 	project2.AuctionType = "blind"
 	err = project2.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	project3.Index = 3
@@ -189,7 +189,7 @@ func InsertDummyData() error {
 	project3.AuctionType = "blind"
 	err = project3.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	pc, err := newOriginator.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1, "blind") // 1 is the idnex for martin

--- a/platforms/opensolar/auctions.go
+++ b/platforms/opensolar/auctions.go
@@ -1,7 +1,7 @@
 package opensolar
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 // Contract auctions are specific for public infrastructure and for projects with multiple stakeholders
@@ -34,7 +34,7 @@ type ContractAuction struct {
 func SelectContractBlind(arr []Project) (Project, error) {
 	var a Project
 	if len(arr) == 0 {
-		return a, fmt.Errorf("Empty array passed!")
+		return a, errors.New("Empty array passed!")
 	}
 	// array is not empty, min 1 elem
 	a = arr[0]
@@ -52,7 +52,7 @@ func SelectContractBlind(arr []Project) (Project, error) {
 func SelectContractVickrey(arr []Project) (Project, error) {
 	var winningContract Project
 	if len(arr) == 0 {
-		return winningContract, fmt.Errorf("Empty array passed!")
+		return winningContract, errors.New("Empty array passed!")
 	}
 	// array is not empty, min 1 elem
 	winningContract = arr[0]
@@ -88,7 +88,7 @@ func SelectContractVickrey(arr []Project) (Project, error) {
 func SelectContractTime(arr []Project) (Project, error) {
 	var a Project
 	if len(arr) == 0 {
-		return a, fmt.Errorf("Empty array passed!")
+		return a, errors.New("Empty array passed!")
 	}
 
 	a = arr[0]

--- a/platforms/opensolar/dbhandlers.go
+++ b/platforms/opensolar/dbhandlers.go
@@ -2,7 +2,7 @@ package opensolar
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 
 	database "github.com/YaleOpenLab/openx/database"
 	utils "github.com/YaleOpenLab/openx/utils"
@@ -13,14 +13,14 @@ import (
 func (a *Project) Save() error {
 	db, err := database.OpenDB()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.ProjectsBucket)
 		encoded, err := json.Marshal(a)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "couldn't marshal json")
 		}
 		return b.Put([]byte(utils.ItoB(a.Index)), encoded)
 	})
@@ -32,14 +32,14 @@ func RetrieveProject(key int) (Project, error) {
 	var inv Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return inv, err
+		return inv, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.ProjectsBucket)
 		x := b.Get(utils.ItoB(key))
 		if x == nil {
-			return fmt.Errorf("Retrieved project nil")
+			return errors.New("Retrieved project nil")
 		}
 		return json.Unmarshal(x, &inv)
 	})
@@ -51,7 +51,7 @@ func RetrieveAllProjects() ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -64,7 +64,7 @@ func RetrieveAllProjects() ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			arr = append(arr, rProject)
 		}
@@ -78,7 +78,7 @@ func RetrieveProjectsAtStage(stage float64) ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -91,7 +91,7 @@ func RetrieveProjectsAtStage(stage float64) ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			if rProject.Stage == stage {
 				arr = append(arr, rProject)
@@ -107,7 +107,7 @@ func RetrieveContractorProjects(stage float64, index int) ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -120,7 +120,7 @@ func RetrieveContractorProjects(stage float64, index int) ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			if rProject.Stage == stage && rProject.Contractor.U.Index == index {
 				arr = append(arr, rProject)
@@ -136,7 +136,7 @@ func RetrieveOriginatorProjects(stage float64, index int) ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -149,7 +149,7 @@ func RetrieveOriginatorProjects(stage float64, index int) ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			if rProject.Stage == stage && rProject.Originator.U.Index == index {
 				arr = append(arr, rProject)
@@ -165,7 +165,7 @@ func RetrieveRecipientProjects(stage float64, index int) ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -178,7 +178,7 @@ func RetrieveRecipientProjects(stage float64, index int) ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return nil
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			if rProject.Stage == stage && rProject.RecipientIndex == index {
 				arr = append(arr, rProject)
@@ -195,7 +195,7 @@ func RetrieveLockedProjects() ([]Project, error) {
 	var arr []Project
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "couldn't open db")
 	}
 	defer db.Close()
 	err = db.View(func(tx *bolt.Tx) error {
@@ -208,7 +208,7 @@ func RetrieveLockedProjects() ([]Project, error) {
 			}
 			err := json.Unmarshal(x, &rProject)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "couldn't marshal json")
 			}
 			if rProject.Lock {
 				arr = append(arr, rProject)
@@ -223,7 +223,7 @@ func RetrieveLockedProjects() ([]Project, error) {
 func SaveOriginatorMoU(projIndex int, hash string) error {
 	a, err := RetrieveProject(projIndex)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't retrieve project")
 	}
 	a.OriginatorMoUHash = hash
 	return a.Save()
@@ -233,7 +233,7 @@ func SaveOriginatorMoU(projIndex int, hash string) error {
 func SaveContractHash(projIndex int, hash string) error {
 	a, err := RetrieveProject(projIndex)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't retrieve project")
 	}
 	a.ContractorContractHash = hash
 	return a.Save()
@@ -243,7 +243,7 @@ func SaveContractHash(projIndex int, hash string) error {
 func SaveInvPlatformContract(projIndex int, hash string) error {
 	a, err := RetrieveProject(projIndex)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't retrieve project")
 	}
 	a.InvPlatformContractHash = hash
 	return a.Save()
@@ -253,7 +253,7 @@ func SaveInvPlatformContract(projIndex int, hash string) error {
 func SaveRecPlatformContract(projIndex int, hash string) error {
 	a, err := RetrieveProject(projIndex)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't retrieve project")
 	}
 	a.RecPlatformContractHash = hash
 	return a.Save()

--- a/platforms/opensolar/entity_originator.go
+++ b/platforms/opensolar/entity_originator.go
@@ -1,8 +1,7 @@
 package opensolar
 
 import (
-	"fmt"
-	"log"
+	"github.com/pkg/errors"
 
 	database "github.com/YaleOpenLab/openx/database"
 	utils "github.com/YaleOpenLab/openx/utils"
@@ -32,7 +31,7 @@ func (contractor *Entity) Originate(panelSize string, totalValue float64, locati
 
 	indexCheck, err := RetrieveAllProjects()
 	if err != nil {
-		return pc, fmt.Errorf("Projects could not be retrieved!")
+		return pc, errors.New("Projects could not be retrieved!")
 	}
 	pc.Index = len(indexCheck) + 1
 	pc.PanelSize = panelSize
@@ -43,7 +42,7 @@ func (contractor *Entity) Originate(panelSize string, totalValue float64, locati
 	pc.DateInitiated = utils.Timestamp()
 	iRecipient, err := database.RetrieveRecipient(recIndex)
 	if err != nil { // recipient does not exist
-		return pc, err
+		return pc, errors.Wrap(err, "couldn't retrieve recipient from db")
 	}
 	pc.RecipientIndex = iRecipient.U.Index
 	pc.Stage = 0 // 0 since we need to filter this out while retrieving the propsoed contracts
@@ -60,12 +59,12 @@ func (contractor *Entity) Originate(panelSize string, totalValue float64, locati
 func RepOriginatedProject(origIndex int, projIndex int) error {
 	originator, err := RetrieveEntity(origIndex)
 	if err != nil {
-		log.Println(err)
+		return errors.Wrap(err, "couldn't retrieve entity from db")
 		return err
 	}
 	project, err := RetrieveProject(projIndex)
 	if err != nil {
-		log.Println(err)
+		return errors.Wrap(err, "couldn't retrieve project from db")
 		return err
 	}
 	return originator.U.IncreaseReputation(project.TotalValue * OriginatorWeight)

--- a/platforms/opensolar/helpers.go
+++ b/platforms/opensolar/helpers.go
@@ -1,7 +1,7 @@
 package opensolar
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 )
 
 // findInKey finds a project within an array of projects, given a key or index
@@ -12,5 +12,5 @@ func findInKey(key int, arr []Project) (Project, error) {
 			return elem, nil
 		}
 	}
-	return dummy, fmt.Errorf("Not found")
+	return dummy, errors.New("Not found")
 }

--- a/platforms/opensolar/opensolar.go
+++ b/platforms/opensolar/opensolar.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"time"
 
-	notif "github.com/YaleOpenLab/openx/notif"
 	consts "github.com/YaleOpenLab/openx/consts"
+	notif "github.com/YaleOpenLab/openx/notif"
 	platform "github.com/YaleOpenLab/openx/platforms"
 )
 

--- a/platforms/ozones/dbhandlers.go
+++ b/platforms/ozones/dbhandlers.go
@@ -2,8 +2,7 @@ package ozones
 
 import (
 	"encoding/json"
-	"fmt"
-	"log"
+	"github.com/pkg/errors"
 
 	database "github.com/YaleOpenLab/openx/database"
 	utils "github.com/YaleOpenLab/openx/utils"
@@ -29,7 +28,7 @@ func NewLivingUnitCoop(mdate string, mrights string, stype string, intrate float
 
 	x, err := RetrieveAllLivingUnitCoops()
 	if err != nil {
-		return coop, err
+		return coop, errors.Wrap(err, "could not retrieve all living unit coops")
 	}
 	coop.Index = len(x) + 1
 	coop.UnitsSold = 0
@@ -58,7 +57,7 @@ func NewConstructionBond(mdate string, stype string, intrate float64, rating str
 
 	x, err := RetrieveAllConstructionBonds()
 	if err != nil {
-		return cBond, err
+		return cBond, errors.Wrap(err, "could not retrieve all living unit coops")
 	}
 
 	cBond.Index = len(x) + 1
@@ -74,15 +73,14 @@ func NewConstructionBond(mdate string, stype string, intrate float64, rating str
 func (a *LivingUnitCoop) Save() error {
 	db, err := database.OpenDB()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.CoopBucket)
 		encoded, err := json.Marshal(a)
 		if err != nil {
-			log.Println("Failed to encode this data into json")
-			return err
+			return errors.Wrap(err, "Failed to marshal json")
 		}
 		return b.Put([]byte(utils.ItoB(a.Index)), encoded)
 	})
@@ -92,15 +90,14 @@ func (a *LivingUnitCoop) Save() error {
 func (a *ConstructionBond) Save() error {
 	db, err := database.OpenDB()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 	err = db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(database.BondBucket)
 		encoded, err := json.Marshal(a)
 		if err != nil {
-			log.Println("Failed to encode this data into json")
-			return err
+			return errors.Wrap(err, "failed to marshal json")
 		}
 		return b.Put([]byte(utils.ItoB(a.Index)), encoded)
 	})
@@ -112,7 +109,7 @@ func RetrieveAllLivingUnitCoops() ([]LivingUnitCoop, error) {
 	var arr []LivingUnitCoop
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 
@@ -126,7 +123,7 @@ func RetrieveAllLivingUnitCoops() ([]LivingUnitCoop, error) {
 			}
 			err := json.Unmarshal(x, &rCoop)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to unmarshal json")
 			}
 			arr = append(arr, rCoop)
 		}
@@ -140,7 +137,7 @@ func RetrieveAllConstructionBonds() ([]ConstructionBond, error) {
 	var arr []ConstructionBond
 	db, err := database.OpenDB()
 	if err != nil {
-		return arr, err
+		return arr, errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 
@@ -154,7 +151,7 @@ func RetrieveAllConstructionBonds() ([]ConstructionBond, error) {
 			}
 			err := json.Unmarshal(x, &rBond)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "failed to unmarshal json")
 			}
 			arr = append(arr, rBond)
 		}
@@ -168,7 +165,7 @@ func RetrieveLivingUnitCoop(key int) (LivingUnitCoop, error) {
 	var bond LivingUnitCoop
 	db, err := database.OpenDB()
 	if err != nil {
-		return bond, err
+		return bond, errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 
@@ -176,7 +173,7 @@ func RetrieveLivingUnitCoop(key int) (LivingUnitCoop, error) {
 		b := tx.Bucket(database.CoopBucket)
 		x := b.Get(utils.ItoB(key))
 		if x == nil {
-			return fmt.Errorf("Retrieved LivingUnitCoop nil")
+			return errors.New("Retrieved LivingUnitCoop nil")
 		}
 		return json.Unmarshal(x, &bond)
 	})
@@ -187,7 +184,7 @@ func RetrieveConstructionBond(key int) (ConstructionBond, error) {
 	var bond ConstructionBond
 	db, err := database.OpenDB()
 	if err != nil {
-		return bond, err
+		return bond, errors.Wrap(err, "coild not open db")
 	}
 	defer db.Close()
 
@@ -195,7 +192,7 @@ func RetrieveConstructionBond(key int) (ConstructionBond, error) {
 		b := tx.Bucket(database.BondBucket)
 		x := b.Get(utils.ItoB(key))
 		if x == nil {
-			return fmt.Errorf("Retreived Bond returns nil")
+			return errors.New("Retreived Bond returns nil")
 		}
 		return json.Unmarshal(x, &bond)
 	})

--- a/rpc/entities.go
+++ b/rpc/entities.go
@@ -1,7 +1,7 @@
 package rpc
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"net/http"
 
@@ -25,13 +25,12 @@ func EntityValidateHelper(w http.ResponseWriter, r *http.Request) (platform.Enti
 	// need to pass the pwhash param here
 	if r.URL.Query() == nil || r.URL.Query()["username"] == nil ||
 		len(r.URL.Query()["pwhash"][0]) != 128 {
-		return prepInvestor, fmt.Errorf("Invalid params passed")
+		return prepInvestor, errors.New("Invalid params passed")
 	}
 
 	prepEntity, err := platform.ValidateEntity(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])
 	if err != nil {
-		log.Println("Error while validating entity", err)
-		return prepEntity, err
+		return prepEntity, errors.Wrap(err, "Error while validating entity")
 	}
 
 	return prepEntity, nil

--- a/rpc/investors.go
+++ b/rpc/investors.go
@@ -1,7 +1,7 @@
 package rpc
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -37,7 +37,7 @@ func parseInvestor(r *http.Request) (database.Investor, error) {
 	var prepInvestor database.Investor
 	err := r.ParseForm()
 	if err != nil || r.FormValue("username") == "" || r.FormValue("pwhash") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
-		return prepInvestor, fmt.Errorf("One of required fields missing: username, pwhash, Name, EPassword")
+		return prepInvestor, errors.New("One of required fields missing: username, pwhash, Name, EPassword")
 	}
 
 	prepInvestor.AmountInvested = float64(0)
@@ -165,7 +165,7 @@ func InvValidateHelper(w http.ResponseWriter, r *http.Request) (database.Investo
 	// need to pass the pwhash param here
 	if r.URL.Query() == nil || r.URL.Query()["username"] == nil ||
 		len(r.URL.Query()["pwhash"][0]) != 128 {
-		return prepInvestor, fmt.Errorf("Invalid params passed")
+		return prepInvestor, errors.New("Invalid params passed")
 	}
 
 	prepInvestor, err := database.ValidateInvestor(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])

--- a/rpc/opensolar.go
+++ b/rpc/opensolar.go
@@ -1,7 +1,7 @@
 package rpc
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"net/http"
 
@@ -43,11 +43,11 @@ func parseProject(r *http.Request) (platform.Project, error) {
 	allProjects, err := platform.RetrieveAllProjects()
 	if err != nil {
 		log.Println("did not retrieve all projects", err)
-		return prepProject, fmt.Errorf("Error in assigning index")
+		return prepProject, errors.New("Error in assigning index")
 	}
 	prepProject.Index = len(allProjects) + 1
 	if r.FormValue("PanelSize") == "" || r.FormValue("TotalValue") == "" || r.FormValue("Location") == "" || r.FormValue("Metadata") == "" || r.FormValue("Stage") == "" {
-		return prepProject, fmt.Errorf("One of given params is missing: PanelSize, TotalValue, Location, Metadata")
+		return prepProject, errors.New("One of given params is missing: PanelSize, TotalValue, Location, Metadata")
 	}
 
 	prepProject.PanelSize = r.FormValue("PanelSize")

--- a/rpc/recipient.go
+++ b/rpc/recipient.go
@@ -1,7 +1,7 @@
 package rpc
 
 import (
-	"fmt"
+	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -44,7 +44,7 @@ func parseRecipient(r *http.Request) (database.Recipient, error) {
 	err := r.ParseForm()
 	if err != nil || r.FormValue("username") == "" || r.FormValue("pwhash") == "" || r.FormValue("Name") == "" || r.FormValue("EPassword") == "" {
 		// don't care which type of error because you send 404 anyway
-		return prepRecipient, fmt.Errorf("One of required fields missing: username, pwhash, Name, EPassword")
+		return prepRecipient, errors.New("One of required fields missing: username, pwhash, Name, EPassword")
 	}
 
 	prepRecipient.U, err = database.NewUser(r.FormValue("username"), r.FormValue("pwhash"), r.FormValue("Name"), r.FormValue("EPassword"))
@@ -155,7 +155,7 @@ func RecpValidateHelper(w http.ResponseWriter, r *http.Request) (database.Recipi
 	// need to pass the pwhash param here
 	if r.URL.Query() == nil || r.URL.Query()["username"] == nil ||
 		len(r.URL.Query()["pwhash"][0]) != 128 {
-		return prepRecipient, fmt.Errorf("Invalid params passed")
+		return prepRecipient, errors.New("Invalid params passed")
 	}
 
 	prepRecipient, err := database.ValidateRecipient(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])

--- a/rpc/users.go
+++ b/rpc/users.go
@@ -1,12 +1,12 @@
 package rpc
 
 import (
+	"crypto/tls"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"crypto/tls"
 
 	assets "github.com/YaleOpenLab/openx/assets"
 	consts "github.com/YaleOpenLab/openx/consts"
@@ -80,7 +80,7 @@ func UserValidateHelper(w http.ResponseWriter, r *http.Request) (database.User, 
 	var err error
 	// need to pass the pwhash param here
 	if r.URL.Query() == nil || r.URL.Query()["username"] == nil || r.URL.Query()["pwhash"] == nil || len(r.URL.Query()["pwhash"][0]) != 128 {
-		return prepUser, fmt.Errorf("Invalid params passed!")
+		return prepUser, errors.New("Invalid params passed!")
 	}
 
 	prepUser, err = database.ValidateUser(r.URL.Query()["username"][0], r.URL.Query()["pwhash"][0])

--- a/scan/scan.go
+++ b/scan/scan.go
@@ -7,6 +7,7 @@ package scan
 import (
 	"bufio"
 	"fmt"
+	"github.com/pkg/errors"
 	"os"
 	"strconv"
 	"syscall"
@@ -19,12 +20,12 @@ func ScanForInt() (int, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if scanner.Err() != nil {
-		return -1, fmt.Errorf("Couldn't read user input")
+		return -1, errors.New("Couldn't read user input")
 	}
 	num := scanner.Text()
 	numI, err := strconv.Atoi(num)
 	if err != nil {
-		return -1, fmt.Errorf("Input not a number")
+		return -1, errors.New("Input not a number")
 	}
 	return numI, nil
 }
@@ -33,7 +34,7 @@ func ScanForFloat() (float64, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if scanner.Err() != nil {
-		return -1, fmt.Errorf("Couldn't read user input")
+		return -1, errors.New("Couldn't read user input")
 	}
 	num := scanner.Text()
 	x, err := strconv.ParseFloat(num, 32)
@@ -45,7 +46,7 @@ func ScanForString() (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if scanner.Err() != nil {
-		return "", fmt.Errorf("Couldn't read user input")
+		return "", errors.New("Couldn't read user input")
 	}
 	inputString := scanner.Text()
 	return inputString, nil
@@ -55,7 +56,7 @@ func ScanForStringWithCheckI() (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if scanner.Err() != nil {
-		return "", fmt.Errorf("Couldn't read user input")
+		return "", errors.New("Couldn't read user input")
 	}
 	inputString := scanner.Text()
 	_, err := strconv.Atoi(inputString) // check whether input string is a number (for payback)
@@ -69,12 +70,12 @@ func ScanForStringWithCheckF() (string, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 	scanner.Scan()
 	if scanner.Err() != nil {
-		return "", fmt.Errorf("Couldn't read user input")
+		return "", errors.New("Couldn't read user input")
 	}
 	inputString := scanner.Text()
 	if utils.StoF(inputString) == 0 {
 		fmt.Println("Amount entered is not a float, quitting")
-		return "", fmt.Errorf("Amount entered is not a float, quitting")
+		return "", errors.New("Amount entered is not a float, quitting")
 	}
 	return inputString, nil
 }

--- a/teller/deviceid.go
+++ b/teller/deviceid.go
@@ -3,7 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"os"
 	"strings"
@@ -18,7 +18,7 @@ func GenerateRandomString(n int) (string, error) {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not read random bytes to generate random string")
 	}
 
 	return hex.EncodeToString(b), nil
@@ -28,7 +28,7 @@ func GenerateRandomString(n int) (string, error) {
 func GenerateDeviceID() (string, error) {
 	rs, err := GenerateRandomString(16)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not generate random string")
 	}
 	upperCase := strings.ToUpper(rs)
 	return upperCase, nil
@@ -44,21 +44,21 @@ func CheckDeviceID() error {
 		path := consts.TellerHomeDir + "/deviceid.hex"
 		file, err := os.Create(path)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not create device id file")
 		}
 		deviceId, err := GenerateDeviceID()
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not generate device id")
 		}
 		ColorOutput("GENERATED UNIQUE DEVICE ID: "+deviceId, GreenColor)
 		_, err = file.Write([]byte(deviceId))
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not write device id to file")
 		}
 		file.Close()
 		err = SetDeviceId(LocalRecipient.U.Username, LocalRecipient.U.Pwhash, deviceId)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "coudl not store device id in remote platform")
 		}
 	}
 	return nil
@@ -69,16 +69,16 @@ func GetDeviceID() (string, error) {
 	path := consts.TellerHomeDir + "/deviceid.hex"
 	file, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not open teller home path")
 	}
 	// read the hex string from the file
 	data := make([]byte, 32)
 	numInt, err := file.Read(data)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "could not read from file")
 	}
 	if numInt != 32 {
-		return "", fmt.Errorf("Length of strings doesn't match, quitting!")
+		return "", errors.New("Length of strings doesn't match, quitting!")
 	}
 	return string(data), nil
 }

--- a/teller/rpc.go
+++ b/teller/rpc.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 	"log"
 	"strings"
 
@@ -56,7 +57,7 @@ func GetProjectIndex(assetName string) (int, error) {
 			return elem.Index, nil
 		}
 	}
-	return -1, fmt.Errorf("Not found")
+	return -1, errors.New("Not found")
 }
 
 func LoginToPlatform(username string, pwhash string) error {
@@ -91,7 +92,7 @@ func ProjectPayback(assetName string, amount string) error {
 		ColorOutput("PAID!", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out")
+	return errors.New("Errored out")
 }
 
 func SetDeviceId(username string, pwhash string, deviceId string) error {
@@ -109,7 +110,7 @@ func SetDeviceId(username string, pwhash string, deviceId string) error {
 		ColorOutput("PAID!", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }
 
 func StoreStartTime() error {
@@ -128,7 +129,7 @@ func StoreStartTime() error {
 		ColorOutput("LOGGED START TIME SUCCESSFULLY!", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }
 
 func StoreLocation(mapskey string) error {
@@ -148,7 +149,7 @@ func StoreLocation(mapskey string) error {
 		ColorOutput("LOGGED LOCATION SUCCESSFULLY!", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }
 
 func GetPlatformEmail() error {
@@ -189,7 +190,7 @@ func SendDeviceShutdownEmail(tx1 string, tx2 string) error {
 		ColorOutput("SENT STOP EMAIL SUCCESSFULLY", GreenColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }
 
 func GetIpfsHash(inputString string) (string, error) {
@@ -250,7 +251,7 @@ func SendDevicePaybackFailedEmail() error {
 		ColorOutput("SENT FAILED PAYBACK EMAIL", RedColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }
 
 func StoreStateHistory(hash string) error {
@@ -270,5 +271,5 @@ func StoreStateHistory(hash string) error {
 		ColorOutput("SENT FAILED PAYBACK EMAIL", RedColor)
 		return nil
 	}
-	return fmt.Errorf("Errored out, didn't receive 200")
+	return errors.New("Errored out, didn't receive 200")
 }

--- a/teller/teller.go
+++ b/teller/teller.go
@@ -145,9 +145,9 @@ func main() {
 	promptColor := color.New(color.FgHiYellow).SprintFunc()
 	whiteColor := color.New(color.FgHiWhite).SprintFunc()
 	rl, err := readline.NewEx(&readline.Config{
-		Prompt:      promptColor("teller") + whiteColor("# "),
-		HistoryFile: consts.TellerHomeDir + "/history.txt",
-		AutoComplete:  AutoComplete(),
+		Prompt:       promptColor("teller") + whiteColor("# "),
+		HistoryFile:  consts.TellerHomeDir + "/history.txt",
+		AutoComplete: AutoComplete(),
 	})
 	defer rl.Close()
 

--- a/testdata.go
+++ b/testdata.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 	"log"
 
 	database "github.com/YaleOpenLab/openx/database"
@@ -123,7 +123,7 @@ func InsertDummyData() error {
 
 	c1, err := solar.NewContractor("john", "p", "x", "John Doe", "14 ABC Street London", "This is a sample contractor")
 	if err != nil {
-		log.Println(err)
+		log.Fatal(err)
 	}
 
 	project1.Index = 1
@@ -145,7 +145,7 @@ func InsertDummyData() error {
 	project1.AuctionType = "blind"
 	err = project1.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	project2.Index = 2
@@ -167,7 +167,7 @@ func InsertDummyData() error {
 	project2.AuctionType = "blind"
 	err = project2.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	project3.Index = 3
@@ -189,7 +189,7 @@ func InsertDummyData() error {
 	project3.AuctionType = "blind"
 	err = project3.Save()
 	if err != nil {
-		return fmt.Errorf("Error inserting project into db")
+		return errors.New("Error inserting project into db")
 	}
 
 	pc, err := newOriginator.Originate("100 16x24 panels on a solar rooftop", 14000, "Puerto Rico", 5, "ABC School in XYZ peninsula", 1, "blind") // 1 is the idnex for martin

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,7 +1,7 @@
 package wallet
 
 import (
-	"fmt"
+	"github.com/pkg/errors"
 	"log"
 
 	aes "github.com/YaleOpenLab/openx/aes"
@@ -29,7 +29,7 @@ func StoreSeed(seed string, password string, path string) error {
 	// these can store the file ion any path passed to them
 	err := aes.EncryptFile(path, []byte(seed), password)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not encrypt file")
 	}
 	_, err = aes.DecryptFile(path, password)
 	return err
@@ -42,11 +42,11 @@ func RetrieveSeed(path string, password string) (string, string, error) {
 	var seed string
 	data, err := aes.DecryptFile(path, password)
 	if err != nil {
-		return publicKey, seed, err
+		return publicKey, seed, errors.Wrap(err, "could not decrypt file")
 	}
 	seed = string(data)
 	keyp, err := keypair.Parse(seed)
-	return keyp.Address(), seed, err
+	return keyp.Address(), seed, errors.Wrap(err, "could not parse seed to get keypair")
 }
 
 // RetrievePubkey restores the publicKey when passed a seed and stores the
@@ -55,7 +55,7 @@ func RetrieveAndStorePubkey(seed string, path string, password string) (string, 
 	var publicKey string
 	keyp, err := keypair.Parse(seed)
 	if err != nil {
-		return publicKey, err
+		return publicKey, errors.Wrap(err, "could not parse seed to get keypair")
 	} else {
 		publicKey = keyp.Address()
 	}
@@ -71,8 +71,8 @@ func DecryptSeed(encryptedSeed []byte, seedpwd string) (string, error) {
 
 func ReturnPubkey(seed string) (string, error) {
 	if len(seed) == 0 {
-		return seed, fmt.Errorf("Empty Seed passed!")
+		return seed, errors.New("Empty Seed passed!")
 	}
 	keyp, err := keypair.Parse(seed)
-	return keyp.Address(), err
+	return keyp.Address(), errors.Wrap(err, "could not parse seed to get keypair")
 }

--- a/xlm/transactions.go
+++ b/xlm/transactions.go
@@ -2,7 +2,7 @@ package xlm
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -17,7 +17,7 @@ func GetTransactionData(txhash string) ([]byte, error) {
 	if err != nil || resp.Status != "200 OK" {
 		// check here since if we don't, we need to check the body of the unmarshalled
 		// response to see if we have 0
-		return data, fmt.Errorf("API Request did not succeed")
+		return data, errors.New("API Request did not succeed")
 	}
 
 	defer resp.Body.Close()
@@ -31,7 +31,7 @@ func GetTransactionHeight(txhash string) (int, error) {
 
 	b, err := GetTransactionData(txhash)
 	if err != nil {
-		return txheight, err
+		return txheight, errors.Wrap(err, "could not get transaction data")
 	}
 	var x protocols.Transaction
 	err = json.Unmarshal(b, &x)


### PR DESCRIPTION
Use pkg/errors to wrap errors and return context to caller and use errors.New instead of fmt.Errorf to get a slight performance boost