### PR TITLE
resolve stablecoin exchange bug

### DIFF
--- a/oracle/oracle.go
+++ b/oracle/oracle.go
@@ -43,6 +43,5 @@ func ExchangeXLMforUSD(amount string) float64 {
 	amountF := utils.StoF(amount)
 	// exchangeRate := 0.1 // hardcode for now, can query cmc apis later
 	exchangeRate := 1000000000.0 // rig the exchange rate so that we can test some stuff
-	premium := 0.01 / 100        // 0.01% premium on ao tx
-	return amountF * (1 - premium) * exchangeRate
+	return amountF * exchangeRate
 }

--- a/oracle/oracle_test.go
+++ b/oracle/oracle_test.go
@@ -28,7 +28,7 @@ func TestOracle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if exchangeFloat != 999900000 {
+	if exchangeFloat != 1000000000 {
 		t.Fatalf("Exchange value does not match")
 	}
 }

--- a/platforms/opensolar/contract.go
+++ b/platforms/opensolar/contract.go
@@ -247,7 +247,7 @@ func Invest(projIndex int, invIndex int, invAmount string, invSeed string) error
 		project.InvestorAssetCode, project.TotalValue, 1)
 	if err != nil {
 		log.Println("Error while seed investing", err)
-		return errors.Wrap(err, "error while seed investing")
+		return errors.Wrap(err, "error while investing")
 	}
 
 	// once the investment is complete, update the project and store in the database

--- a/stablecoin/exchange.go
+++ b/stablecoin/exchange.go
@@ -3,6 +3,7 @@ package stablecoin
 import (
 	"github.com/pkg/errors"
 	"log"
+	"time"
 
 	assets "github.com/YaleOpenLab/openx/assets"
 	consts "github.com/YaleOpenLab/openx/consts"
@@ -86,12 +87,12 @@ func OfferExchange(publicKey string, seed string, invAmount string) error {
 		exchangeRate := oracle.ExchangeXLMforUSD("1")
 		// 1 xlm can fetch exchangeRate USD, how much xlm does diff USD need?
 		amountToExchange := diff / exchangeRate
-
 		err = Exchange(publicKey, seed, utils.FtoS(amountToExchange))
 		if err != nil {
 			return errors.New("Unable to exchange XLM for USD and automate payment. Please get more STABLEUSD to fulfil the payment")
 		}
 	}
 
+	time.Sleep(5 * time.Second) // 5 seconds for issuing stalbeusd to the person who's requested for it
 	return nil
 }


### PR DESCRIPTION
concurrency meant auto-exchange didn't work. Also the extra premium charged made it difficult to estimate the stablecoin amount needed (since we have a high exchange rate)