### PR TITLE
migrate stablecoin to new horizon package

### DIFF
--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,1 @@
+"github.com/stellar/go/build"

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -413,10 +413,6 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = CheckUsernameCollision("recipient1")
-	if err == nil {
-		t.Fatalf("recipient username collision not picked up")
-	}
 	err = user.ChangeReputation(1.0)
 	if err != nil {
 		t.Fatal(err)

--- a/database/user.go
+++ b/database/user.go
@@ -730,7 +730,7 @@ func (a *User) Generate2FA() (string, error) {
 	return otpString, nil
 }
 
-// Authenticate2FA authenticates tghe the given password against the user's stored password
+// Authenticate2FA authenticates the given password against the user's stored password
 func (a *User) Authenticate2FA(password string) (bool, error) {
 	secretBase32 := base32.StdEncoding.EncodeToString([]byte(a.TwoFASecret))
 	otpc := &googauth.OTPConfig{

--- a/emulator/helpers.go
+++ b/emulator/helpers.go
@@ -196,7 +196,7 @@ func exchangeHelper(input []string, username string, pwhash string, seed string)
 	}
 	// convert this to int and check if int
 	fmt.Println("Exchanging", amount, "XLM for STABLEUSD")
-	response, err := GetStableCoin(username, pwhash, seed, input[1])
+	response, err := GetStableCoin(username, pwhash, input[1])
 	if err != nil {
 		log.Println(err)
 		return

--- a/emulator/rpc.go
+++ b/emulator/rpc.go
@@ -83,9 +83,9 @@ func GetAssetBalance(username string, pwhash string, asset string) (string, erro
 	return x, nil
 }
 
-func GetStableCoin(username string, pwhash string, seed string, amount string) (rpc.StatusResponse, error) {
+func GetStableCoin(username string, pwhash string, amount string) (rpc.StatusResponse, error) {
 	var x rpc.StatusResponse
-	data, err := rpc.GetRequest(ApiUrl + "/stablecoin/get?" + "seed=" + seed + "&amount=" +
+	data, err := rpc.GetRequest(ApiUrl + "/stablecoin/get?" + "seedpwd=" + LocalSeedPwd + "&amount=" +
 		amount + "&username=" + username + "&pwhash=" + pwhash)
 	if err != nil {
 		return x, err

--- a/platforms/opensolar/escrow.go
+++ b/platforms/opensolar/escrow.go
@@ -72,5 +72,6 @@ func initMultisigEscrow(pubkey1 string) (string, error) {
 
 // SendFundsFromEscrow sends funds to a destination address from the project escrow
 func SendFundsFromEscrow(escrowPubkey string, destination string, signer1 string, amount string, memo string) error {
-	return multisig.Tx2of2(escrowPubkey, signer1, consts.PlatformSeed, amount, memo)
+	log.Println("ESCROW PUBKEY: ", escrowPubkey, "destination: ", destination, "signer1: ", signer1, "amount: ", amount, "memo: ", memo)
+	return multisig.Tx2of2(escrowPubkey, destination, signer1, consts.PlatformSeed, amount, memo)
 }

--- a/platforms/opensolar/opensolar_test.go
+++ b/platforms/opensolar/opensolar_test.go
@@ -858,9 +858,9 @@ func TestDb(t *testing.T) {
 		t.Fatalf("stage promotion works without satisfying checklist, quitting!")
 	}
 
-	consts.PlatformSeed = "SBODXH3TJCBWQCVHAEUJZQGCHC7CKAOOI6DA3DFMI5GIK4M6I7KQ7ZSG"
-	consts.PlatformPublicKey = "GCHKX52XNXJ4PWG4TJYR7SEHFBBVDJWRGA22ELSISYLMRCDRSBLSL3MH"
-	consts.StablecoinPublicKey = "GCSMRNO2NBLVULZAIAHA7PAPMFXXLFMLMEAZ23XPNGWMNSY2RL6GJYZR"
+	consts.PlatformSeed = "SA6Q7TOCQTJZGPR2BSQ4AK6QWRJA4LA2FBUW35CK6GIPW3Q3OOG3HL23"
+	consts.PlatformPublicKey = "GCBWNXTD65I7I3NFE5P2HQDYOQHFARABOQLVMRADX2OTMTIJWB4I3OLX"
+	consts.StablecoinPublicKey = "SC3FVSRP6ZMDILVI2OSGF2WYVFZPWITN4HMJBGP223XBJU62PU7YIK3S"
 	seed1, pubkey1, err := xlm.GetKeyPair()
 	if err != nil {
 		t.Fatal(err)
@@ -873,10 +873,11 @@ func TestDb(t *testing.T) {
 
 	escrowPubkey, err := initMultisigEscrow(pubkey1)
 	if err != nil {
+		log.Println(err)
 		t.Fatal(err)
 	}
 
-	err = SendFundsFromEscrow(escrowPubkey, escrowPubkey, seed1, "10", "testescrowtx")
+	err = SendFundsFromEscrow(escrowPubkey, pubkey1, seed1, "1", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stablecoin/stablecoin.go
+++ b/stablecoin/stablecoin.go
@@ -19,17 +19,17 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
+	"time"
 
 	consts "github.com/YaleOpenLab/openx/consts"
-	oracle "github.com/YaleOpenLab/openx/oracle"
 	scan "github.com/YaleOpenLab/openx/scan"
-	utils "github.com/YaleOpenLab/openx/utils"
 	xlm "github.com/YaleOpenLab/openx/xlm"
-	assets "github.com/YaleOpenLab/openx/xlm/assets"
 	wallet "github.com/YaleOpenLab/openx/xlm/wallet"
 	"github.com/pkg/errors"
-	"github.com/stellar/go/clients/horizon"
+	horizon "github.com/stellar/go/clients/horizonclient"
+	"github.com/stellar/go/protocols/horizon/operations"
 )
 
 // InitStableCoin returns the platform structure and the seed
@@ -67,65 +67,32 @@ func InitStableCoin() error {
 	// the user doesn't have seed, so create a new platform
 	consts.StablecoinPublicKey = publicKey
 	consts.StablecoinSeed = seed
-	go ListenForPayments()
+
+	client := DefaultTestNetClient
+	// all payments
+	opRequest := horizon.OperationRequest{ForAccount: consts.StableCoinAddress}
+
+	ctx, _ := context.WithCancel(context.Background()) // cancel
+	go func() {
+		// Stop streaming after 60 seconds.
+		log.Println("monitoring payments made towards address")
+		time.Sleep(5 * time.Second) // refresh the thread every 5 seconds to check for payments
+		// cancel() don't cancel the handler, let it run indefinitely
+	}()
+
+	printHandler := func(op operations.Operation) {
+		log.Println("stablecoin operation: ", op)
+	}
+	err := client.StreamPayments(ctx, opRequest, printHandler)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
+
 	return nil
 }
 
-// ListenForPayments listens for payments to the stablecoin account and once it
-// gets the transaction hash from the rmeote API, calculates how much USD it owes
-// for the amount deposited and then transfers the StableUSD asset to the payee
-// Prices are retrieved from an oracle.
-func ListenForPayments() {
-	// the publicKey above has to be hardcoded as a constant because stellar's API wants it like so
-	// stupid stuff, but we need to go ahead with it. In reality, this shouldn't
-	// be much of a problem since we expect that the platform's seed will be
-	// constant
-	ctx := context.Background() // start in the background context
-	cursor := horizon.Cursor("now")
-	fmt.Println("Waiting for a payment...")
-	err := xlm.TestNetClient.StreamPayments(ctx, consts.StableCoinAddress, &cursor, func(payment horizon.Payment) {
-		/*
-			Sample Response:
-			Payment type payment
-			Payment From GC76MINOSNQUMDBNONBARFYFCCQA5QLNQSJOVANR5RNQVHQRB5B46B6I
-			Payment To GBAACP6UUXZAB5ZAYAHWEYLNKORWB36WVBZBXWNPFXQTDY2AIQFM6D7Y
-			Payment Asset Type native
-			Payment Asset Code
-			Payment Asset Issuer
-			Payment Amount 10.0000000
-			Payment Memo Type
-			Payment Memo
-		*/
-		log.Println("Stablecoin payment to/from detected")
-		log.Println("Payment type", payment.Type)
-		log.Println("Payment From", payment.From)
-		log.Println("Payment To", payment.To)
-		log.Println("Payment Asset Type", payment.AssetType)
-		log.Println("Payment Asset Code", payment.AssetCode)
-		log.Println("Payment Asset Issuer", payment.AssetIssuer)
-		log.Println("Payment Amount", payment.Amount)
-		log.Println("Payment Memo Type", payment.Memo.Type)
-		log.Println("Payment Memo", payment.Memo.Value)
-		if payment.Type == "payment" && payment.AssetType == "native" {
-			// store the stuff that we want here
-			payee := payment.From
-			amount := payment.Amount
-			log.Printf("Received request for stablecoin from %s worth %s", payee, amount)
-			xlmWorth := oracle.ExchangeXLMforUSD(amount)
-			log.Println("The deposited amount is worth: ", xlmWorth)
-			// now send the stableusd asset over to this guy
-			_, hash, err := assets.SendAssetFromIssuer(consts.StablecoinCode, payee, utils.FtoS(xlmWorth), consts.StablecoinSeed, consts.StablecoinPublicKey)
-			if err != nil {
-				log.Println("Error while sending USD Assets back to payee: ", payee, err)
-				//  don't skip here, there's technically nothing we can do
-			}
-			log.Println("Successful payment, hash: ", hash)
-		}
-	})
-
-	if err != nil {
-		// we shouldn't ideally fatal here, but do since we're testing out stuff
-		log.Println("stablecoin daemon not initialized: ", err)
-		return
-	}
+var DefaultTestNetClient = &horizon.Client{
+	HorizonURL: "https://horizon-testnet.stellar.org/",
+	HTTP:       http.DefaultClient,
 }

--- a/stablecoin/stablecoin.go
+++ b/stablecoin/stablecoin.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"time"
 
@@ -68,7 +67,7 @@ func InitStableCoin() error {
 	consts.StablecoinPublicKey = publicKey
 	consts.StablecoinSeed = seed
 
-	client := DefaultTestNetClient
+	client := xlm.TestNetClient
 	// all payments
 	opRequest := horizon.OperationRequest{ForAccount: consts.StableCoinAddress}
 
@@ -90,9 +89,4 @@ func InitStableCoin() error {
 	}
 
 	return nil
-}
-
-var DefaultTestNetClient = &horizon.Client{
-	HorizonURL: "https://horizon-testnet.stellar.org/",
-	HTTP:       http.DefaultClient,
 }

--- a/xlm/consts.go
+++ b/xlm/consts.go
@@ -3,16 +3,16 @@ package xlm
 import (
 	"net/http"
 
-	clients "github.com/stellar/go/clients/horizon"
+	horizon "github.com/stellar/go/clients/horizonclient"
 	"github.com/stellar/go/network"
 )
 
 // constants that are imported by other packages
 
 // TestNetClient defines the horizon client to connect to
-var TestNetClient = &clients.Client{
-	URL:  "https://horizon-testnet.stellar.org",
-	HTTP: http.DefaultClient,
+var TestNetClient = &horizon.Client{
+	HorizonURL: "https://horizon-testnet.stellar.org/",
+	HTTP:       http.DefaultClient,
 }
 
 var Passphrase = network.TestNetworkPassphrase

--- a/xlm/dex/dex.go
+++ b/xlm/dex/dex.go
@@ -7,9 +7,9 @@ import (
 	consts "github.com/YaleOpenLab/openx/consts"
 	oracle "github.com/YaleOpenLab/openx/oracle"
 	utils "github.com/YaleOpenLab/openx/utils"
+	xlm "github.com/YaleOpenLab/openx/xlm"
 	"github.com/stellar/go/network"
 	build "github.com/stellar/go/txnbuild"
-	xlm "github.com/YaleOpenLab/openx/xlm"
 )
 
 // package dex contains functions for interfacing with the stellar dex

--- a/xlm/horizon.go
+++ b/xlm/horizon.go
@@ -17,7 +17,7 @@ import (
 func GetLedgerData(blockNumber string) ([]byte, error) {
 	var err error
 	var data []byte
-	resp, err := http.Get(TestNetClient.URL + "/ledgers/" + blockNumber)
+	resp, err := http.Get(TestNetClient.HorizonURL + "/ledgers/" + blockNumber)
 	if err != nil || resp.Status != "200 OK" {
 		return data, errors.New("API Request did not succeed")
 	}
@@ -43,7 +43,7 @@ func GetBlockHash(blockNumber string) (string, error) {
 
 // GetLatestBlockHash gets the lastest block hash
 func GetLatestBlockHash() (string, error) {
-	url := TestNetClient.URL + "/ledgers?cursor=now&order=desc&limit=1"
+	url := TestNetClient.HorizonURL + "/ledgers?cursor=now&order=desc&limit=1"
 	resp, err := http.Get(url)
 	if err != nil || resp.Status != "200 OK" {
 		return "", errors.New("API Request did not succeed")
@@ -79,7 +79,7 @@ func GetLatestBlockHash() (string, error) {
 func GetAccountData(a string) ([]byte, error) {
 	var err error
 	var data []byte
-	resp, err := http.Get(TestNetClient.URL + "/accounts/" + a)
+	resp, err := http.Get(TestNetClient.HorizonURL + "/accounts/" + a)
 	if err != nil {
 		return data, errors.Wrap(err, "could not get /accounts/ endpoint from API")
 	}
@@ -162,7 +162,8 @@ func GetAssetTrustLimit(publicKey string, assetName string) (string, error) {
 // GetAllBalances calls the stellar testnet API to get all the balances associated
 // with a certain account.
 func GetAllBalances(publicKey string) ([]protocols.Balance, error) {
-	account, err := TestNetClient.LoadAccount(publicKey)
+
+	account, err := ReturnSourceAccountPubkey(publicKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load account")
 	}
@@ -171,8 +172,8 @@ func GetAllBalances(publicKey string) ([]protocols.Balance, error) {
 
 // HasStableCoin checks whether the PublicKey has a stablecoin balance associated
 // with it in the first place, if not, returns false
-func HasStableCoin(PublicKey string) bool {
-	account, err := TestNetClient.LoadAccount(PublicKey)
+func HasStableCoin(publicKey string) bool {
+	account, err := ReturnSourceAccountPubkey(publicKey)
 	if err != nil {
 		// account does not exist
 		return false
@@ -190,7 +191,7 @@ func HasStableCoin(PublicKey string) bool {
 func GetTransactionData(txhash string) ([]byte, error) {
 	var err error
 	var data []byte
-	resp, err := http.Get(TestNetClient.URL + "/transactions/" + txhash)
+	resp, err := http.Get(TestNetClient.HorizonURL + "/transactions/" + txhash)
 	if err != nil || resp.Status != "200 OK" {
 		// check here since if we don't, we need to check the body of the unmarshalled
 		// response to see if we have 0

--- a/xlm/horizon_test.go
+++ b/xlm/horizon_test.go
@@ -45,13 +45,13 @@ func TestApi(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldTc := TestNetClient.URL
-	TestNetClient.URL = "blah"
+	oldTc := TestNetClient.HorizonURL
+	TestNetClient.HorizonURL = "blah"
 	_, err = GetLatestBlockHash()
 	if err == nil {
 		t.Fatalf("can call with invalid client URL")
 	}
-	TestNetClient.URL = oldTc
+	TestNetClient.HorizonURL = oldTc
 }
 
 func TestBalances(t *testing.T) {
@@ -71,13 +71,13 @@ func TestBalances(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Invalid account exists, quitting!")
 	}
-	oldTc := TestNetClient.URL
-	TestNetClient.URL = "blah"
+	oldTc := TestNetClient.HorizonURL
+	TestNetClient.HorizonURL = "blah"
 	_, err = GetAccountData("blah")
 	if err == nil {
 		t.Fatalf("Can return data with invalid url, quitting!")
 	}
-	TestNetClient.URL = oldTc
+	TestNetClient.HorizonURL = oldTc
 	if balance != "5.9996700" {
 		log.Println("CHECKBAL:", balance)
 		t.Fatalf("Balance doesn't match with remote API, quitting!")

--- a/xlm/multisig/multisig.go
+++ b/xlm/multisig/multisig.go
@@ -3,19 +3,11 @@ package multisig
 import (
 	"github.com/pkg/errors"
 	"log"
-	"net/http"
 
 	xlm "github.com/YaleOpenLab/openx/xlm"
-	clients "github.com/stellar/go/clients/horizon"
 	"github.com/stellar/go/keypair"
 	build "github.com/stellar/go/txnbuild"
 )
-
-var TestNetClient = &clients.Client{
-	// URL: "http://35.192.122.229:8080",
-	URL:  "https://horizon-testnet.stellar.org",
-	HTTP: http.DefaultClient,
-}
 
 // AddSigner is used to add a signer to the account with Public Key pubkey
 func addSigner(seed string, pubkey string, cosignerPubkey string) error {
@@ -139,15 +131,16 @@ func New2of2(cosigner1Pubkey string, cosigner2Pubkey string) (string, error) {
 }
 
 // SendTx sends the multisig tx. Copied from xlm/ to  avoid import cycles
-func SendTx(tx string) error {
+func SendTx(txXdr string) (int32, string, error) {
 
-	resp, err := TestNetClient.SubmitTransaction(tx)
+	resp, err := xlm.TestNetClient.SubmitTransactionXDR(txXdr)
 	if err != nil {
-		return errors.Wrap(err, "could not submit tx to horizon")
+		return -1, "", errors.Wrap(err, "could not submit tx to horizon")
 	}
 
 	log.Printf("Propagated Transaction: %s, sequence: %d\n", resp.Hash, resp.Ledger)
-	return err
+
+	return resp.Ledger, resp.Hash, nil
 }
 
 // Tx2of2 constructs a tx where the source account pubkey1 is the 2of2 account, we need 2 signers for this tx
@@ -186,7 +179,8 @@ func Tx2of2(pubkey1 string, signer1 string, signer2 string, amount string, memo 
 		return errors.Wrap(err, "second party couldn't sign tx")
 	}
 
-	return SendTx(txe)
+	_, _, err = SendTx(txe)
+	return err
 }
 
 // AuthImmutable2of2 sets the auth immutable flag on a multisig account
@@ -222,7 +216,8 @@ func AuthImmutable2of2(pubkey1 string, signer1 string, signer2 string) error {
 		return errors.Wrap(err, "second party couldn't sign tx")
 	}
 
-	return SendTx(txe)
+	_, _, err = SendTx(txe)
+	return err
 }
 
 // TrustAssetTx trusts a specific asset
@@ -259,7 +254,8 @@ func TrustAssetTx(assetCode string, assetIssuer string, limit string, pubkey str
 		return errors.Wrap(err, "second party couldn't sign tx")
 	}
 
-	return SendTx(txe)
+	_, _, err = SendTx(txe)
+	return err
 }
 
 // Convert2of2 converts the account with pubkey myPubkey to a 2of2 multisig account

--- a/xlm/multisig/multisig.go
+++ b/xlm/multisig/multisig.go
@@ -144,14 +144,14 @@ func SendTx(txXdr string) (int32, string, error) {
 }
 
 // Tx2of2 constructs a tx where the source account pubkey1 is the 2of2 account, we need 2 signers for this tx
-func Tx2of2(pubkey1 string, signer1 string, signer2 string, amount string, memo string) error {
+func Tx2of2(pubkey1 string, destination string, signer1 string, signer2 string, amount string, memo string) error {
 	sourceAccount, err := xlm.ReturnSourceAccountPubkey(pubkey1)
 	if err != nil {
 		return errors.Wrap(err, "could not load account details, quitting")
 	}
 
 	op := build.Payment{
-		Destination: pubkey1,
+		Destination: destination,
 		Amount:      amount,
 		Asset:       build.NativeAsset{},
 	}

--- a/xlm/xlm.go
+++ b/xlm/xlm.go
@@ -27,8 +27,8 @@ func GetKeyPair() (string, string, error) {
 
 // AccountExists checks whether an account exists, not needed now since we do the check ourselves
 // in multiple places
-func AccountExists(address string) bool {
-	_, err := TestNetClient.LoadAccount(address)
+func AccountExists(publicKey string) bool {
+	_, err := ReturnSourceAccountPubkey(publicKey)
 	return !(err != nil)
 	/*
 		if err != nil {
@@ -44,7 +44,7 @@ func SendTx(mykp keypair.KP, tx build.Transaction) (int32, string, error) {
 		return -1, "", err
 	}
 
-	resp, err := TestNetClient.SubmitTransaction(txe)
+	resp, err := TestNetClient.SubmitTransactionXDR(txe)
 	if err != nil {
 		return -1, "", errors.Wrap(err, "could not submit tx to horizon")
 	}

--- a/xlm/xlm_test.go
+++ b/xlm/xlm_test.go
@@ -3,7 +3,6 @@
 package xlm
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -120,8 +119,8 @@ func TestXLM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldTc := TestNetClient.URL
-	TestNetClient.URL = "blah"
+	oldTc := TestNetClient.HorizonURL
+	TestNetClient.HorizonURL = "blah"
 	_, _, err = SetAuthImmutable(seed)
 	if err == nil {
 		t.Fatalf("can send tx with an invalid client url, quitting!")
@@ -130,7 +129,7 @@ func TestXLM(t *testing.T) {
 	if err == nil {
 		t.Fatalf("can send tx with an invalid client url, quitting!")
 	}
-	TestNetClient.URL = oldTc
+	TestNetClient.HorizonURL = oldTc
 }
 
 func trustAsset(assetCode string, assetIssuer string, limit string, seed string) (string, error) {


### PR DESCRIPTION
looks like the stablecoin scheme broke due to stellar's package deprecation. Updated in line with stellar's recent changes.