### PR TITLE
add admin users to rpc

### DIFF
--- a/database/user.go
+++ b/database/user.go
@@ -163,6 +163,12 @@ func NewUser(uname string, pwd string, seedpwd string, Name string) (User, error
 
 	a.Name = Name
 	a.Username = uname
+
+	_, err = CheckUsernameCollision(uname)
+	if err != nil {
+		return a, errors.Wrap(err, "username collision")
+	}
+
 	a.Pwhash = utils.SHA3hash(pwd) // store tha sha3 hash
 	// now we have a new User, take this and then send this struct off to be stored in the database
 	a.FirstSignedUp = utils.Timestamp()
@@ -514,7 +520,7 @@ func (a *User) GiveFeedback(userIndex int, feedback int) error {
 
 // Generate2FA generates a new 2FA secret for the given user
 func (a *User) Generate2FA() (string, error) {
-	secret := utils.GetRandomString(35) // multiples of 5 to  prevent the = padding at the end
+	secret := utils.GetRandomString(35) // multiples of 5 to prevent the = padding at the end
 	secretBase32 := base32.StdEncoding.EncodeToString([]byte(secret))
 	otpc := &googauth.OTPConfig{
 		Secret:     secretBase32,

--- a/rpc/admin.go
+++ b/rpc/admin.go
@@ -1,0 +1,93 @@
+package rpc
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	erpc "github.com/Varunram/essentials/rpc"
+	utils "github.com/Varunram/essentials/utils"
+	consts "github.com/YaleOpenLab/openx/consts"
+)
+
+// admin contains a list of all the functions that will hopefully never be used in practice
+// but if needed are incredibly powerful
+
+func adminHandlers() {
+	killServer()
+	freezeServer()
+	genNuclearCode()
+}
+
+var KillCode string
+
+func validateAdmin(w http.ResponseWriter, r *http.Request) bool {
+	erpc.CheckGet(w, r)
+	erpc.CheckOrigin(w, r)
+
+	prepUser, err := CheckReqdParams(w, r)
+	if err != nil {
+		return false
+	}
+	if !prepUser.Admin {
+		return false
+	}
+	return true
+}
+
+// killServer instantly kills the server. Recovery possible only with server access
+func killServer() {
+	http.HandleFunc("/admin/kill", func(w http.ResponseWriter, r *http.Request) {
+		// need to pass the pwhash param here
+		if !validateAdmin(w, r) {
+			// admin account not accessible
+			if r.URL.Query()["nuke"] != nil {
+				if r.URL.Query()["nuke"][0] == KillCode {
+					log.Println("nuclear code activated, killing server")
+				}
+			} else {
+				erpc.ResponseHandler(w, erpc.StatusUnauthorized)
+				return
+			}
+		}
+
+		if r.URL.Query()["username"][0] == "martin" {
+			// only certain admins can access this endpoint, can be compiled at runtime
+			log.Println("Activating kill switch")
+			os.Exit(1)
+		}
+	})
+}
+
+// freezeServer freezes the server to make all transactions void. The easiest way to do that
+// is to set the Mainnet const to false.
+func freezeServer() {
+	http.HandleFunc("/admin/freeze", func(w http.ResponseWriter, r *http.Request) {
+		// need to pass the pwhash param here
+		if !validateAdmin(w, r) {
+			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
+			return
+		}
+
+		consts.Mainnet = false
+		consts.SetConsts() // runtime const migration
+		log.Println("Server frozen, state reverted to mainnet. Restart server to unfreeze")
+	})
+}
+
+func genNuclearCode() {
+	http.HandleFunc("/admin/gennuke", func(w http.ResponseWriter, r *http.Request) {
+		// need to pass the pwhash param here
+		if !validateAdmin(w, r) {
+			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
+			return
+		}
+
+		if r.URL.Query()["username"][0] == "martin" {
+			// only authorized users, can change at compile time
+			log.Println("generating new nuclear code")
+			KillCode = utils.GetRandomString(64)
+			w.Write([]byte(KillCode))
+		}
+	})
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -46,6 +46,7 @@ func StartServer(portx int, insecure bool) {
 	setupStagesHandlers()
 	setupAnchorHandlers()
 	setupCAHandlers()
+	adminHandlers()
 
 	port, err := utils.ToString(portx)
 	if err != nil {

--- a/rpc/users.go
+++ b/rpc/users.go
@@ -3,7 +3,7 @@ package rpc
 import (
 	"crypto/tls"
 	"encoding/json"
-	"errors"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"log"
 	"math"

--- a/test.go
+++ b/test.go
@@ -70,6 +70,18 @@ func main() {
 		}
 	}
 
+	/*
+		user, err := database.RetrieveUser(1)
+		if err != nil {
+			log.Fatal(err)
+		}
+		user.Admin = true
+		err = user.Save()
+		if err != nil {
+			log.Fatal(err)
+		}
+	*/
+	// rpc.KillCode = "NUKE" // compile time nuclear code
 	// run this only when you need to monitor the tellers. Not required for local testing.
 	// go opensolar.MonitorTeller(1)
 	rpc.StartServer(port, insecure)


### PR DESCRIPTION
admins can kill or freeze the server. And generate emergency codes which can shutdown the server in case their account is hacked or something similar.