### PR TITLE
Catch defers in program execution

### DIFF
--- a/chains/xlm/horizon.go
+++ b/chains/xlm/horizon.go
@@ -25,7 +25,13 @@ func GetLedgerData(blockNumberx int) ([]byte, error) {
 	if err != nil || resp.Status != "200 OK" {
 		return data, errors.New("API Request did not succeed")
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if ferr := resp.Body.Close() ; ferr != nil {
+			err = ferr
+		}
+	}()
+
 	data, err = ioutil.ReadAll(resp.Body)
 	return data, err
 }
@@ -53,7 +59,13 @@ func GetLatestBlockHash() (string, error) {
 	if err != nil || resp.Status != "200 OK" {
 		return "", errors.New("API Request did not succeed")
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if ferr := resp.Body.Close() ; ferr != nil {
+			err = ferr
+		}
+	}()
+
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "could not read response body")
@@ -92,7 +104,12 @@ func GetAccountData(a string) ([]byte, error) {
 		return data, errors.New("Request did not succeed")
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if ferr := resp.Body.Close() ; ferr != nil {
+			err = ferr
+		}
+	}()
+
 	data, err = ioutil.ReadAll(resp.Body)
 	return data, err
 }
@@ -197,7 +214,12 @@ func GetTransactionData(txhash string) ([]byte, error) {
 		return data, errors.New("API Request did not succeed")
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if ferr := resp.Body.Close() ; ferr != nil {
+			err = ferr
+		}
+	}()
+
 	data, err = ioutil.ReadAll(resp.Body)
 	return data, err
 }

--- a/rpc/complyadvantage.go
+++ b/rpc/complyadvantage.go
@@ -108,7 +108,12 @@ func PostRequestCA(body string, payload io.Reader) ([]byte, error) {
 		return dummy, err
 	}
 
-	defer res.Body.Close()
+	defer func() {
+		if ferr := res.Body.Close() ; ferr != nil {
+			err = ferr
+		}
+	}()
+
 	x, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		log.Println("did not read from ioutil", err)
@@ -147,7 +152,6 @@ func searchComplyAdvantage() {
 		}
 		_, err = userValidateHelper(w, r, CARPC[1][1:])
 		if err != nil {
-			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
 			return
 		}
 
@@ -197,7 +201,6 @@ func getAllCAUsers() {
 
 		_, err = userValidateHelper(w, r, CARPC[2][1:])
 		if err != nil {
-			erpc.ResponseHandler(w, erpc.StatusUnauthorized)
 			return
 		}
 

--- a/rpc/users.go
+++ b/rpc/users.go
@@ -580,7 +580,12 @@ func uploadFile() {
 			erpc.ResponseHandler(w, erpc.StatusBadRequest)
 			return
 		}
-		defer file.Close()
+
+		defer func() {
+			if ferr := file.Close() ; ferr != nil {
+				err = ferr
+			}
+		}()
 
 		supportedType := false
 		header := fileHeader.Header.Get("Content-Type")
@@ -723,7 +728,13 @@ func tellerPing() {
 			erpc.ResponseHandler(w, erpc.StatusInternalServerError)
 			return
 		}
-		defer res.Body.Close()
+
+		defer func() {
+			if ferr := res.Body.Close() ; ferr != nil {
+				err = ferr
+			}
+		}()
+
 		data, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			erpc.ResponseHandler(w, erpc.StatusInternalServerError)


### PR DESCRIPTION
`defer body.Close()` ignores the error from the close itself and in some cases this may not be caught and cause problems. This can be easily solved by wrapping the function call in a defer function which assigns generated error to the `err` variable outside the defer function's scope.