### PR TITLE
update SHA hashes after new builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ debian.deb
 ci/ci
 ci/secret.txt
 ci/lastbuilt.txt
+*.gz

--- a/ci/serverci.go
+++ b/ci/serverci.go
@@ -348,8 +348,6 @@ func main() {
 	}
 
 	readGhSecret()
-	updateShastruct()
-	// writeLastBuilt()
 	readLastBuilt()
 
 	go func() {
@@ -363,6 +361,7 @@ func main() {
 			}
 			log.Println("build built succesfully")
 			writeLastBuilt()
+			updateShastruct()
 		}
 	}()
 


### PR DESCRIPTION
we used to update hashes when loading the script, which is the wrong way to go about doing it.