### PR TITLE
add timeout option for platforms

### DIFF
--- a/ci/serverci.go
+++ b/ci/serverci.go
@@ -14,22 +14,22 @@ import (
 
 	erpc "github.com/Varunram/essentials/rpc"
 	utils "github.com/Varunram/essentials/utils"
-	flags "github.com/jessevdk/go-flags"
 	btcutils "github.com/bithyve/research/utils"
+	flags "github.com/jessevdk/go-flags"
 )
 
 var (
-	LastBuilt string
-	GithubSecret string
-	Sha Shastruct
-	OpenxHashes FileStats
+	LastBuilt       string
+	GithubSecret    string
+	Sha             Shastruct
+	OpenxHashes     FileStats
 	OpensolarHashes FileStats
-	TellerHashes FileStats
+	TellerHashes    FileStats
 )
 
 type FileStats struct {
 	Hashes []string
-	Sizes []int64
+	Sizes  []int64
 }
 
 func openx() {
@@ -203,7 +203,6 @@ func teller() {
 	})
 }
 
-
 func lastbuilt() {
 	http.HandleFunc("/lastbuilt", func(w http.ResponseWriter, r *http.Request) {
 		err := erpc.CheckGet(w, r)
@@ -229,9 +228,9 @@ func shaEndpoint() {
 }
 
 type HashesResponse struct {
-	Openx FileStats
+	Openx     FileStats
 	Opensolar FileStats
-	Teller FileStats
+	Teller    FileStats
 }
 
 func hashesEndpoint() {
@@ -250,7 +249,6 @@ func hashesEndpoint() {
 		erpc.MarshalSend(w, x)
 	})
 }
-
 
 func frontend() {
 	http.Handle("/fe/", http.StripPrefix("/fe/", http.FileServer(http.Dir("./static"))))
@@ -345,7 +343,7 @@ type GithubSha struct {
 }
 
 type Shastruct struct {
-	OpenxSha string
+	OpenxSha     string
 	OpensolarSha string
 }
 
@@ -397,7 +395,7 @@ func updateShaHashes() {
 			log.Println(err)
 			continue
 		}
-		OpenxHashes.Sizes = append(OpenxHashes.Sizes, x.Size() / 1000000)
+		OpenxHashes.Sizes = append(OpenxHashes.Sizes, x.Size()/1000000)
 	}
 
 	for _, file := range opensolarFileNames {
@@ -413,7 +411,7 @@ func updateShaHashes() {
 			log.Println(err)
 			continue
 		}
-		OpensolarHashes.Sizes = append(OpensolarHashes.Sizes, x.Size() / 1000000)
+		OpensolarHashes.Sizes = append(OpensolarHashes.Sizes, x.Size()/1000000)
 	}
 
 	for _, file := range tellerFileNames {
@@ -429,7 +427,7 @@ func updateShaHashes() {
 			log.Println(err)
 			continue
 		}
-		TellerHashes.Sizes = append(TellerHashes.Sizes, x.Size() / 1000000)
+		TellerHashes.Sizes = append(TellerHashes.Sizes, x.Size()/1000000)
 	}
 }
 

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	utils "github.com/Varunram/essentials/utils"
 	xlm "github.com/YaleOpenLab/openx/chains/xlm"
 	assets "github.com/YaleOpenLab/openx/chains/xlm/assets"
 	consts "github.com/YaleOpenLab/openx/consts"
 	build "github.com/stellar/go/txnbuild"
-	utils "github.com/Varunram/essentials/utils"
 )
 
 // go test --tags="all" -coverprofile=test.txt .

--- a/database/platform.go
+++ b/database/platform.go
@@ -5,18 +5,20 @@ import (
 	"github.com/pkg/errors"
 
 	edb "github.com/Varunram/essentials/database"
+	utils "github.com/Varunram/essentials/utils"
 	consts "github.com/YaleOpenLab/openx/consts"
 )
 
 // Platform is a struct which holds all platform related info
 type Platform struct {
-	Index int
-	Name  string
-	Code  string
+	Index   int
+	Name    string
+	Code    string
+	Timeout int64
 }
 
 // NewPlatform creates a new platform and stores it in the database
-func NewPlatform(name string, code string) error {
+func NewPlatform(name string, code string, timeout bool) error {
 	index, err := RetrieveAllPfLim()
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve all keys from the database")
@@ -26,7 +28,8 @@ func NewPlatform(name string, code string) error {
 	x.Index = index + 1
 	x.Name = name
 	x.Code = code
-
+	x.Timeout = utils.Unix() + 2600000 // 10 months
+	// timeout is set to true by default
 	return x.Save()
 }
 

--- a/rpc/platforms.go
+++ b/rpc/platforms.go
@@ -68,7 +68,7 @@ func authPlatform(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	for _, platform := range platforms {
-		if platform.Code == code {
+		if platform.Code == code && utils.Unix() < platform.Timeout {
 			return nil
 		}
 	}

--- a/test.go
+++ b/test.go
@@ -115,15 +115,15 @@ func main() {
 	}
 
 	/*
-	user, err := database.RetrieveUser(1)
-	if err != nil {
-		log.Fatal(err)
-	}
-	user.Admin = true
-	err = user.Save()
-	if err != nil {
-		log.Fatal(err)
-	}
+		user, err := database.RetrieveUser(1)
+		if err != nil {
+			log.Fatal(err)
+		}
+		user.Admin = true
+		err = user.Save()
+		if err != nil {
+			log.Fatal(err)
+		}
 	*/
 	// rpc.KillCode = "NUKE" // compile time nuclear code
 	// run this only when you need to monitor the tellers. Not required for local testing.


### PR DESCRIPTION
default is 2.6m seconds, can be set to false if desired so. Setting timeouts for each platform might be a pain for platform admins, so the option is not given but an option is given to turn off timeouts which can be done for platforms which are trusted (or run by us, in the case of opensolar). closes #255